### PR TITLE
Don't Watch Vim Swap Files

### DIFF
--- a/cli/domain/watch.js
+++ b/cli/domain/watch.js
@@ -10,7 +10,7 @@ module.exports = function(dirs, baseDir, changed){
       ignoreDotFiles: false
     }, function(fileName, currentStat, previousStat){
       if(!!currentStat || !!previousStat){
-        if(/node_modules|package.tar.gz|_package/gi.test(fileName) === false){
+        if(/node_modules|package.tar.gz|_package|\.sw(o|p)/gi.test(fileName) === false){
           changed(null, fileName);
         }
       }


### PR DESCRIPTION
Prevents OC from watching and reloading Vim swap files in dev.