### PR TITLE
first go at preprocessors

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "opn": "1.0.1",
     "read": "1.0.5",
     "semver": "4.3.3",
-    "spawn-sync": "^1.0.11",
+    "spawn-sync": "1.0.11",
     "stringformat": "0.0.5",
     "tar.gz": "0.1.1",
     "uglify-js": "2.4.13",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "opn": "1.0.1",
     "read": "1.0.5",
     "semver": "4.3.3",
+    "spawn-sync": "^1.0.11",
     "stringformat": "0.0.5",
     "tar.gz": "0.1.1",
     "uglify-js": "2.4.13",


### PR DESCRIPTION
First go is just using shell commands, e.g.

package.json:
```
{
  "oc": {
    "preprocessors": [
      {
        "name": "babel",
        "command": "babel"
      }
    ] 
  }
}
```

Downside is that it requires the `babel` cli to be installed, and it doesn't support commands that don't stream. The order matters.

`coffeescript` can be done using the following:

```
{
  "oc": {
    "files": {
        "data": "server.coffee"
    },
    "preprocessors": [
      {
        "name": "coffee-script",
        "command": "coffee",
        "args": ["-sc"]
      }
    ] 
  }
}
```

