### PR TITLE
Support minifying ie8 compatible css files

### DIFF
--- a/cli/domain/local.js
+++ b/cli/domain/local.js
@@ -102,7 +102,7 @@ module.exports = function(){
   };
 
   var missingDependencies = function(requires, component){
-    return _.filter(requires, function(dep){ 
+    return _.filter(requires, function(dep){
       return !_.contains(_.keys(component.dependencies), dep);
     });
   };
@@ -229,7 +229,7 @@ module.exports = function(){
 
           localConfig.components[componentName] = componentVersion;
           fs.writeJson(settings.configFile.src, localConfig, callback);
-        });      
+        });
       });
     },
     mock: function(params, callback){
@@ -379,8 +379,9 @@ module.exports = function(){
 
                 fs.writeFileSync(fileDestination, minifiedContent);
               } else if(minify && fileExt === '.css' && component.oc.minify !== false){
-                fileContent = fs.readFileSync(filePath).toString(),
-                minifiedContent = new CleanCss().minify(fileContent).styles;
+                fileContent = fs.readFileSync(filePath).toString();
+                var options = (component.oc.ie8css === true) ? {compatibility:'ie8'} : null;
+                minifiedContent = new CleanCss(options).minify(fileContent).styles;
 
                 fs.writeFileSync(fileDestination, minifiedContent);
               } else {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,6 +85,7 @@ The basic package file `package.json` looks as follows:
 |`oc.files.template.type`|`string`|the template engine's type, by default `handlebars`|
 |`oc.files.static`|`array of strings`|An array of directories that contain static resources referenced from the component's markup|
 |`oc.minify`|`boolean`|Default `true`, will minify static css and js files during publishing|
+|`oc.ie8css`|`boolean`|Default `false`, if true, will minify ie8 compatible css files during publishing|
 |`oc.plugins`|`array of strings`|the [plugins](registry.md#plugins) the component requires|
 
 ## Template


### PR DESCRIPTION
Found one issue when publishing reservation-widgets. Test page cannot render background image in css files. It turns out a `clean-css` configuration issue during publishing.
Refer to: https://github.com/jakubpawlowicz/clean-css#how-to-set-compatibility-mode.

Now we can use `oc.ie8css = true` to minify ie8 compatible css files.