### PR TITLE
Static subfolders packaging bugfix

### DIFF
--- a/cli/domain/local.js
+++ b/cli/domain/local.js
@@ -1,13 +1,10 @@
 'use strict';
 
-var async = require('async');
-var CleanCss = require('clean-css');
 var detective = require('detective');
 var format = require('stringformat');
 var fs = require('fs-extra');
 var handlebars = require('handlebars');
 var jade = require('jade');
-var nodeDir = require('node-dir');
 var path = require('path');
 var Targz = require('tar.gz');
 var uglifyJs = require('uglify-js');

--- a/cli/domain/local.js
+++ b/cli/domain/local.js
@@ -14,6 +14,7 @@ var uglifyJs = require('uglify-js');
 var _ = require('underscore');
 
 var hashBuilder = require('../../utils/hash-builder');
+var packageStaticFiles = require('./package-static-files');
 var request = require('../../utils/request');
 var settings = require('../../resources/settings');
 var validator = require('../../registry/domain/validators');
@@ -359,52 +360,13 @@ module.exports = function(){
 
       fs.writeJsonSync(path.join(publishPath, 'package.json'), component);
 
-      var copyDir = function(staticComponent, staticPath, cb){
-        if(!fs.existsSync(staticPath)){
-          return cb('"' + staticPath + '" not found');
-        } else if(!fs.lstatSync(staticPath).isDirectory()){
-          return cb('"' + staticPath + '" must be a directory');
-        } else {
-          nodeDir.paths(staticPath, function(err, res){
-            fs.ensureDirSync(path.join(publishPath, staticComponent));
-            _.forEach(res.files, function(filePath){
-              var fileName = path.basename(filePath),
-                  fileExt = path.extname(filePath),
-                  fileDestination = path.join(publishPath, staticComponent, fileName),
-                  fileContent,
-                  minifiedContent;
-
-              if(minify && fileExt === '.js' && component.oc.minify !== false){
-                fileContent = fs.readFileSync(filePath).toString();
-                minifiedContent = uglifyJs.minify(fileContent, {fromString: true}).code;
-
-                fs.writeFileSync(fileDestination, minifiedContent);
-              } else if(minify && fileExt === '.css' && component.oc.minify !== false){
-                fileContent = fs.readFileSync(filePath).toString();
-                var options = (component.oc.ie8css === true) ? {compatibility:'ie8'} : null;
-                minifiedContent = new CleanCss(options).minify(fileContent).styles;
-
-                fs.writeFileSync(fileDestination, minifiedContent);
-              } else {
-                fs.copySync(filePath, fileDestination);
-              }
-            });
-            cb(null, 'ok');
-          });
-        }
-      };
-
-      if(component.oc.files.static.length === 0){
-        return callback(null, component);
-      }
-      async.eachSeries(component.oc.files.static, function(staticDir, cb){
-        copyDir(staticDir, path.join(componentPath, staticDir), cb);
-      }, function(errors){
-        if(errors){
-          return callback(errors);
-        }
-
-        callback(null, component);
+      packageStaticFiles({
+        componentPath: componentPath, 
+        publishPath: publishPath, 
+        minify: minify, 
+        ocOptions: component.oc
+      }, function(err, res){
+        return callback(err, component);
       });
     },
     unlink: function(componentName, callback){

--- a/cli/domain/package-static-files.js
+++ b/cli/domain/package-static-files.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var async = require('async');
+var CleanCss = require('clean-css');
+var fs = require('fs-extra');
+var nodeDir = require('node-dir');
+var path = require('path');
+var uglifyJs = require('uglify-js');
+var _ = require('underscore');
+
+var minifyFile = function(fileType, fileContent, ocOptions){
+
+  if(fileType === '.js'){
+    return uglifyJs.minify(fileContent, { fromString: true }).code;
+  } else if(fileType === '.css'){
+    var options = (ocOptions.ie8css === true) ? { compatibility:'ie8' } : null;
+    return new CleanCss(options).minify(fileContent).styles;
+  }
+
+  return fileContent;
+};
+
+var copyDir = function(params, cb){
+  var staticPath = path.join(params.componentPath, params.staticDir);
+  if(!fs.existsSync(staticPath)){
+    return cb('"' + staticPath + '" not found');
+  } else if(!fs.lstatSync(staticPath).isDirectory()){
+    return cb('"' + staticPath + '" must be a directory');
+  } else {
+
+    nodeDir.paths(staticPath, function(err, res){
+      _.forEach(res.files, function(filePath){
+    
+        var fileName = path.basename(filePath),
+            fileExt = path.extname(filePath).toLowerCase(),
+            fileRelativePath = path.relative(staticPath, path.dirname(filePath)),
+            fileDestinationPath = path.join(params.publishPath, params.staticDir, fileRelativePath),
+            fileDestination = path.join(fileDestinationPath, fileName);
+
+        fs.ensureDirSync(fileDestinationPath);
+
+        if(params.minify && params.ocOptions.minify !== false && (fileExt === '.js' || fileExt === '.css')){
+          var fileContent = fs.readFileSync(filePath).toString(),
+              minified = minifyFile(fileExt, fileContent, params.ocOptions);
+
+          fs.writeFileSync(fileDestination, minified);
+        } else {
+          fs.copySync(filePath, fileDestination);
+        }
+      });
+      cb(null, 'ok');
+    });
+  }
+};
+
+module.exports = function(params, callback){
+  if(params.ocOptions.files.static.length === 0){
+    return callback(null, 'ok');
+  }
+
+  async.eachSeries(params.ocOptions.files.static, function(staticDir, cb){
+    copyDir(_.extend(params, { staticDir: staticDir }), cb);
+  }, function(errors){
+    if(errors){ return callback(errors); }
+    callback(null, 'ok');
+  });
+};

--- a/package.json
+++ b/package.json
@@ -1,1 +1,76 @@
-{"name":"oc","version":"0.16.21","description":"A framework for developing and distributing html components","main":"index.js","bin":{"oc":"./oc-cli.js"},"scripts":{"test":"grunt test"},"engines":{"node":">=0.10.35"},"repository":{"type":"git","url":"https://github.com/opentable/oc"},"author":"Matteo Figus","license":"MIT","bugs":{"url":"https://github.com/opentable/oc/issues"},"homepage":"https://github.com/opentable/oc","keywords":["open components","components","oc"],"devDependencies":{"chai":"1.10.0","cheerio":"0.18.0","grunt":"0.4.5","grunt-contrib-jshint":"0.10.0","grunt-karma":"0.10.1","grunt-mocha-test":"0.12.7","injectr":"0.5.1","jasmine-core":"2.2.0","karma":"0.12.31","karma-jasmine":"0.3.5","karma-phantomjs-launcher":"0.1.4","karma-sauce-launcher":"0.2.11","karma-sinon":"1.0.4","load-grunt-tasks":"0.6.0","mocha":"2.2.4","sinon":"1.14.1"},"dependencies":{"accept-language-parser":"1.0.2","async":"0.9.0","aws-sdk":"2.1.43","clean-css":"3.1.9","cli-table":"0.3.1","colors":"1.0.3","detective":"4.0.0","express":"3.20.2","form-data":"0.1.4","fs-extra":"0.12.0","handlebars":"3.0.1","jade":"1.9.1","multer":"0.1.4","nice-cache":"0.0.5","node-dir":"0.1.5","nomnom":"1.8.1","npm":"2.9.0","omelette":"0.3.1","opn":"1.0.1","read":"1.0.5","semver":"4.3.3","stringformat":"0.0.5","tar.gz":"0.1.1","uglify-js":"2.4.13","underscore":"1.8.1","watch":"0.13.0"}}
+{
+  "name": "oc",
+  "version": "0.16.21",
+  "description": "A framework for developing and distributing html components",
+  "main": "index.js",
+  "bin": {
+    "oc": "./oc-cli.js"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "engines": {
+    "node": ">=0.10.35"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/opentable/oc"
+  },
+  "author": "Matteo Figus",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/opentable/oc/issues"
+  },
+  "homepage": "https://github.com/opentable/oc",
+  "keywords": [
+    "open components",
+    "components",
+    "oc"
+  ],
+  "devDependencies": {
+    "chai": "1.10.0",
+    "cheerio": "0.18.0",
+    "grunt": "0.4.5",
+    "grunt-contrib-jshint": "0.10.0",
+    "grunt-karma": "0.10.1",
+    "grunt-mocha-test": "0.12.7",
+    "injectr": "0.5.1",
+    "jasmine-core": "2.2.0",
+    "karma": "0.12.31",
+    "karma-jasmine": "0.3.5",
+    "karma-phantomjs-launcher": "0.1.4",
+    "karma-sauce-launcher": "0.2.11",
+    "karma-sinon": "1.0.4",
+    "load-grunt-tasks": "0.6.0",
+    "mocha": "2.2.4",
+    "sinon": "1.14.1"
+  },
+  "dependencies": {
+    "accept-language-parser": "1.0.2",
+    "async": "0.9.0",
+    "aws-sdk": "2.1.43",
+    "clean-css": "3.1.9",
+    "cli-table": "0.3.1",
+    "colors": "1.0.3",
+    "detective": "4.0.0",
+    "express": "3.20.2",
+    "form-data": "0.1.4",
+    "fs-extra": "0.12.0",
+    "handlebars": "3.0.1",
+    "jade": "1.9.1",
+    "multer": "0.1.4",
+    "nice-cache": "0.0.5",
+    "node-dir": "0.1.9",
+    "nomnom": "1.8.1",
+    "npm": "2.9.0",
+    "omelette": "0.3.1",
+    "opn": "1.0.1",
+    "read": "1.0.5",
+    "semver": "4.3.3",
+    "stringformat": "0.0.5",
+    "tar.gz": "0.1.1",
+    "uglify-js": "2.4.13",
+    "underscore": "1.8.1",
+    "watch": "0.13.0"
+  }
+}

--- a/resources/index.js
+++ b/resources/index.js
@@ -51,6 +51,8 @@ module.exports = {
       COMPONENT_HREF_NOT_FOUND: 'The specified path is not a valid component\'s url',
       COMPONENTS_LINKED_NOT_FOUND: 'No components linked in the project',
       COMPONENTS_NOT_FOUND: 'no components found in specified path',
+      FOLDER_IS_NOT_A_FOLDER: '"{0}" must be a directory',
+      FOLDER_NOT_FOUND: '"{0}" not found',
       DEV_FAIL: 'An error happened when initialising the dev runner: {0}',
       INIT_FAIL: 'An error happened when initialising the component: {0}',
       INVALID_CREDENTIALS: 'Invalid credentials',

--- a/test/unit/cli-domain-local.js
+++ b/test/unit/cli-domain-local.js
@@ -36,7 +36,8 @@ var initialise = function(){
       resolve: function(){
         return _.toArray(arguments).join('/');
       }
-    }
+    },
+    './package-static-files': sinon.stub().yields(null, 'ok')
   }, { __dirname: '' });
 
   var local = new Local();

--- a/test/unit/cli-domain-package-static-files.js
+++ b/test/unit/cli-domain-package-static-files.js
@@ -1,0 +1,337 @@
+'use strict';
+
+var expect = require('chai').expect;
+var injectr = require('injectr');
+var path = require('path');
+var sinon = require('sinon');
+
+var packageStaticFiles,
+    error,
+    mocks;
+
+var initialise = function(mocks, params, cb){
+  packageStaticFiles = injectr('../../cli/domain/package-static-files.js', mocks, { console: console });
+  packageStaticFiles(params, function(e, r){
+    error = e;
+    cb();
+  });
+};
+
+var cleanup = function(){
+  error = null;
+  mocks = {
+    'clean-css': sinon.stub().returns({
+      minify: function(){
+        return { styles: 'this-is-minified'};
+      }
+    }),
+    'fs-extra': {
+      copySync: sinon.spy(),
+      ensureDirSync: sinon.spy(),
+      existsSync: sinon.stub().returns(true),
+      lstatSync: sinon.stub().returns({
+        isDirectory: function(){ return true; }
+      }),
+      readFileSync: sinon.stub().returns('some content'),
+      writeFileSync: sinon.spy()
+    },
+    'node-dir': { paths: sinon.stub().yields(null, { files:[] })},
+    'uglify-js': { minify: sinon.stub().returns({
+      code: 'this-is-minified'
+    })}
+  };
+};
+
+cleanup();
+
+describe('cli : domain : packageStaticFiles', function(){
+
+  describe('when oc.files.static is empty', function(){
+
+    beforeEach(function(done){
+      initialise(mocks, {
+        componentPath: '/path/to/component',
+        minify: false,
+        ocOptions: { files: { static: [] }},
+        publishPath: '/path/to/component/_package'
+      }, done);
+    });
+
+    afterEach(cleanup);
+
+    it('should do nothing', function(){
+      expect(mocks['fs-extra'].copySync.called).to.be.false;
+      expect(mocks['fs-extra'].writeFileSync.called).to.be.false;
+    });
+  });
+
+  describe('when oc.files.static contains not valid folder', function(){
+
+    describe('when folder does not exist', function(){
+
+      beforeEach(function(done){
+        mocks['fs-extra'].existsSync = sinon.stub().returns(false);
+
+        initialise(mocks, {
+          componentPath: '/path/to/component',
+          minify: false,
+          ocOptions: { files: { static: [ 'thisDoesNotExist' ]}},
+          publishPath: '/path/to/component/_package'
+        }, done);
+      });
+
+      afterEach(cleanup);
+
+      it('should do nothing', function(){
+        expect(mocks['fs-extra'].copySync.called).to.be.false;
+        expect(mocks['fs-extra'].writeFileSync.called).to.be.false;
+        expect(error).to.equal('"/path/to/component/thisDoesNotExist" not found');
+      });
+    });
+
+    describe('when folder is not a folder', function(){
+
+      beforeEach(function(done){
+        mocks['fs-extra'].lstatSync = sinon.stub().returns({
+          isDirectory: function(){ return false; }
+        });
+
+        initialise(mocks, {
+          componentPath: '/path/to/component',
+          minify: false,
+          ocOptions: { files: { static: [ 'thisDoesNotExist' ]}},
+          publishPath: '/path/to/component/_package'
+        }, done);
+      });
+
+      afterEach(cleanup);
+
+      it('should do nothing', function(){
+        expect(mocks['fs-extra'].copySync.called).to.be.false;
+        expect(mocks['fs-extra'].writeFileSync.called).to.be.false;
+        expect(error).to.equal('"/path/to/component/thisDoesNotExist" must be a directory');
+      });
+    });
+  });
+
+  describe('when oc.files.static contains valid folder', function(){
+
+    describe('when copying folder with image', function(){
+      beforeEach(function(done){
+        mocks['node-dir'].paths.yields(null, {
+          files: ['/path/to/component/img/file.png']
+        });
+
+        initialise(mocks, {
+          componentPath: '/path/to/component',
+          minify: false,
+          ocOptions: { files: { static: [ 'img' ]}},
+          publishPath: '/path/to/component/_package'
+        }, done);
+      });
+
+      afterEach(cleanup);
+
+      it('should not get an error', function(){
+        expect(error).to.be.null;
+      });
+
+      it('should copy the file in the folder', function(){
+        expect(mocks['fs-extra'].copySync.calledOnce).to.be.true;
+      });
+
+      it('should copy the file to the right destination', function(){
+        expect(mocks['fs-extra'].copySync.args[0][1]).to.equal('/path/to/component/_package/img/file.png');
+      });
+    });
+
+    describe('when copying folder with sub-folders', function(){
+      beforeEach(function(done){
+        mocks['node-dir'].paths.yields(null, {
+          files: [
+            '/path/to/component/img/file.png',
+            '/path/to/component/img/subfolder/file2.png'
+          ]
+        });
+
+        initialise(mocks, {
+          componentPath: '/path/to/component',
+          minify: false,
+          ocOptions: { files: { static: [ 'img' ]}},
+          publishPath: '/path/to/component/_package'
+        }, done);
+      });
+
+      afterEach(cleanup);
+
+      it('should not get an error', function(){
+        expect(error).to.be.null;
+      });
+
+      it('should copy the files to the folder', function(){
+        expect(mocks['fs-extra'].copySync.calledTwice).to.be.true;
+      });
+
+      it('should copy the files to the right destinations', function(){
+        expect(mocks['fs-extra'].copySync.args[0][1]).to.equal('/path/to/component/_package/img/file.png');
+        expect(mocks['fs-extra'].copySync.args[1][1]).to.equal('/path/to/component/_package/img/subfolder/file2.png');
+      });
+    });
+
+    describe('when copying folder with js file', function(){
+
+      beforeEach(function(){
+        mocks['node-dir'].paths.yields(null, {
+          files: ['/path/to/component/js/file.js']
+        });
+      });
+
+      afterEach(cleanup);
+
+      describe('when minify=false', function(){
+        beforeEach(function(done){
+          initialise(mocks, {
+            componentPath: '/path/to/component',
+            minify: false,
+            ocOptions: { files: { static: [ 'js' ]}},
+            publishPath: '/path/to/component/_package'
+          }, done);
+        });
+
+        it('should not get an error', function(){
+          expect(error).to.be.null;
+        });
+
+        it('should copy the file in the folder', function(){
+          expect(mocks['fs-extra'].copySync.calledOnce).to.be.true;
+        });
+
+        it('should copy the file to the right destination', function(){
+          expect(mocks['fs-extra'].copySync.args[0][1]).to.equal('/path/to/component/_package/js/file.js');
+        });
+      });
+
+      describe('when minify=true', function(){
+        beforeEach(function(done){
+          initialise(mocks, {
+            componentPath: '/path/to/component',
+            minify: true,
+            ocOptions: { files: { static: [ 'js' ]}},
+            publishPath: '/path/to/component/_package'
+          }, done);
+        });
+
+        it('should not get an error', function(){
+          expect(error).to.be.null;
+        });
+
+        it('should first minify the file', function(){
+          expect(mocks['fs-extra'].readFileSync.calledOnce).to.be.true;
+          expect(mocks['uglify-js'].minify.calledOnce).to.be.true;
+        });
+
+        it('should save the file in the folder', function(){
+          expect(mocks['fs-extra'].writeFileSync.calledOnce).to.be.true;
+        });
+
+        it('should save the file minified', function(){
+          expect(mocks['fs-extra'].writeFileSync.args[0][1]).to.equal('this-is-minified');
+        });
+
+        it('should save the file to the right destination', function(){
+          expect(mocks['fs-extra'].writeFileSync.args[0][0]).to.equal('/path/to/component/_package/js/file.js');
+        });
+      });
+    });
+
+
+    describe('when copying folder with css file', function(){
+
+      beforeEach(function(){
+        mocks['node-dir'].paths.yields(null, {
+          files: ['/path/to/component/css/file.css']
+        });
+      });
+
+      afterEach(cleanup);
+
+      describe('when minify=false', function(){
+        beforeEach(function(done){
+          initialise(mocks, {
+            componentPath: '/path/to/component',
+            minify: false,
+            ocOptions: { files: { static: [ 'css' ]}},
+            publishPath: '/path/to/component/_package'
+          }, done);
+        });
+
+        it('should not get an error', function(){
+          expect(error).to.be.null;
+        });
+
+        it('should copy the file in the folder', function(){
+          expect(mocks['fs-extra'].copySync.calledOnce).to.be.true;
+        });
+
+        it('should copy the file to the right destination', function(){
+          expect(mocks['fs-extra'].copySync.args[0][1]).to.equal('/path/to/component/_package/css/file.css');
+        });
+      });
+
+      describe('when minify=true', function(){
+        beforeEach(function(done){
+          initialise(mocks, {
+            componentPath: '/path/to/component',
+            minify: true,
+            ocOptions: { files: { static: [ 'css' ]}},
+            publishPath: '/path/to/component/_package'
+          }, done);
+        });
+
+        afterEach(cleanup);
+
+        it('should not get an error', function(){
+          expect(error).to.be.null;
+        });
+
+        it('should first minify the file', function(){
+          expect(mocks['fs-extra'].readFileSync.calledOnce).to.be.true;
+          expect(mocks['clean-css'].calledOnce).to.be.true;
+        });
+
+        it('should save the file in the folder', function(){
+          expect(mocks['fs-extra'].writeFileSync.calledOnce).to.be.true;
+        });
+
+        it('should save the file minified', function(){
+          expect(mocks['fs-extra'].writeFileSync.args[0][1]).to.equal('this-is-minified');
+        });
+
+        it('should save the file to the right destination', function(){
+          expect(mocks['fs-extra'].writeFileSync.args[0][0]).to.equal('/path/to/component/_package/css/file.css');
+        });
+      });
+
+      describe('when minify=true and oc.ie8css=true', function(){
+        beforeEach(function(done){
+          initialise(mocks, {
+            componentPath: '/path/to/component',
+            minify: true,
+            ocOptions: { ie8css: true, files: { static: [ 'css' ]}},
+            publishPath: '/path/to/component/_package'
+          }, done);
+        });
+
+        afterEach(cleanup);
+
+        it('should not get an error', function(){
+          expect(error).to.be.null;
+        });
+
+        it('should minify the file with compatibility=ie8', function(){
+          expect(mocks['clean-css'].args[0][0]).to.be.eql({ compatibility: 'ie8' });
+        });
+      });
+    });
+  });
+});

--- a/test/unit/cli-domain-package-static-files.js
+++ b/test/unit/cli-domain-package-static-files.js
@@ -4,6 +4,7 @@ var expect = require('chai').expect;
 var injectr = require('injectr');
 var path = require('path');
 var sinon = require('sinon');
+var _ = require('underscore');
 
 var packageStaticFiles,
     error,
@@ -36,6 +37,22 @@ var cleanup = function(){
       writeFileSync: sinon.spy()
     },
     'node-dir': { paths: sinon.stub().yields(null, { files:[] })},
+    path: {
+      basename: path.basename,
+      dirname: function(){
+        return path.dirname.apply(this, _.toArray(arguments)).replace(/\\/g, '/');
+      },
+      extname: path.extname,
+      join: function(){
+        return path.join.apply(this, _.toArray(arguments)).replace(/\\/g, '/');
+      },
+      relative: function(){
+        return path.relative.apply(this, _.toArray(arguments)).replace(/\\/g, '/');
+      },
+      resolve: function(){
+        return _.toArray(arguments).join('/');
+      }
+    },
     'uglify-js': { minify: sinon.stub().returns({
       code: 'this-is-minified'
     })}


### PR DESCRIPTION
When packaging component with static folders containing subfolders, the package does not correctly organises all the files.

Given a folder may have subfolders, the only parameter that should be specified in the `package.json` is the folder. All the subfolders should be packaged as well.

This should fix.

FYI @ajcw @pbazydlo @tpgmartin @andyroyle (I remember discussing about this with some of you)