### PR TITLE
add support for dynamic plugin mocks

### DIFF
--- a/cli/commands.js
+++ b/cli/commands.js
@@ -45,7 +45,7 @@ module.exports = {
       }
     },
 
-    ls: { 
+    ls: {
       help: 'Shows the list of the available components for a linked oc registry',
       options: {
         registry: {
@@ -66,7 +66,7 @@ module.exports = {
           help: 'The item to mock'
         },
         targetValue: {
-          help: 'The mocked value'
+          help: 'The mocked value (static plugin) or the file to read (dynamic plugin)'
         }
       }
     },

--- a/cli/domain/get-mocked-plugins.js
+++ b/cli/domain/get-mocked-plugins.js
@@ -3,32 +3,66 @@
 var fs = require('fs-extra');
 var path = require('path');
 var _ = require('underscore');
-
+var strings = require('../../resources/');
 var settings = require('../../resources/settings');
 
-module.exports = function(){
-  var mockedPlugins = [],
+var registerStaticMocks = function(mocks, logger){
+    return _.map(mocks, function(mockedValue, pluginName){
+      logger.log('├── '.green + pluginName + ' () => ' + mockedValue);
+      return {
+        name: pluginName,
+        register: {
+          register: function(options, next){
+            return next();
+          },
+          execute: function(){
+            return mockedValue;
+          }
+        }
+      };
+    });
+};
+
+var registerDynamicMocks = function(mocks, logger){
+    return _.map(mocks, function(source, pluginName){
+      var p;
+      try {
+        p = require(path.resolve(source));
+      } catch(er) {
+        logger.log(er.toString().red);
+        return;
+      }
+
+      logger.log('├── '.green + pluginName + ' () => [Function]');
+      return {
+        name: pluginName,
+        register: {
+          register: function(options, next){
+            return next();
+          },
+          execute: p
+        }
+      };
+    });
+};
+
+module.exports = function(logger){
+  var plugins = [],
       ocJsonPath = path.resolve(settings.configFile.src);
 
-  if(fs.existsSync(ocJsonPath)){
-    var content = fs.readJsonSync(ocJsonPath);
-
-    if(!!content.mocks && !!content.mocks.plugins && !!content.mocks.plugins.static){
-      _.forEach(content.mocks.plugins.static, function(mockedValue, pluginName){
-        mockedPlugins.push({
-          name: pluginName,
-          register: {
-            register: function(options, next){
-              return next();
-            },
-            execute: function(){
-              return mockedValue;
-            }
-          }
-        });
-      });
-    }
+  if(!fs.existsSync(ocJsonPath)){
+    return plugins;
   }
 
-  return mockedPlugins;
+  var content = fs.readJsonSync(ocJsonPath);
+  if(!content.mocks || !content.mocks.plugins){
+    return plugins;
+  }
+
+  logger.log(strings.messages.cli.REGISTERING_MOCKED_PLUGINS.yellow);
+
+  plugins = plugins.concat(registerStaticMocks(content.mocks.plugins.static, logger));
+  plugins = plugins.concat(registerDynamicMocks(content.mocks.plugins.dynamic, logger));
+
+  return plugins;
 };

--- a/cli/domain/get-mocked-plugins.js
+++ b/cli/domain/get-mocked-plugins.js
@@ -7,43 +7,43 @@ var strings = require('../../resources/');
 var settings = require('../../resources/settings');
 
 var registerStaticMocks = function(mocks, logger){
-    return _.map(mocks, function(mockedValue, pluginName){
-      logger.log('├── '.green + pluginName + ' () => ' + mockedValue);
-      return {
-        name: pluginName,
-        register: {
-          register: function(options, next){
-            return next();
-          },
-          execute: function(){
-            return mockedValue;
-          }
+  return _.map(mocks, function(mockedValue, pluginName){
+    logger.log('├── '.green + pluginName + ' () => ' + mockedValue);
+    return {
+      name: pluginName,
+      register: {
+        register: function(options, next){
+          return next();
+        },
+        execute: function(){
+          return mockedValue;
         }
-      };
-    });
+      }
+    };
+  });
 };
 
 var registerDynamicMocks = function(mocks, logger){
-    return _.map(mocks, function(source, pluginName){
-      var p;
-      try {
-        p = require(path.resolve(source));
-      } catch(er) {
-        logger.log(er.toString().red);
-        return;
-      }
+  return _.map(mocks, function(source, pluginName){
+    var p;
+    try {
+      p = require(path.resolve(source));
+    } catch(er) {
+      logger.log(er.toString().red);
+      return;
+    }
 
-      logger.log('├── '.green + pluginName + ' () => [Function]');
-      return {
-        name: pluginName,
-        register: {
-          register: function(options, next){
-            return next();
-          },
-          execute: p
-        }
-      };
-    });
+    logger.log('├── '.green + pluginName + ' () => [Function]');
+    return {
+      name: pluginName,
+      register: {
+        register: function(options, next){
+          return next();
+        },
+        execute: p
+      }
+    };
+  });
 };
 
 module.exports = function(logger){

--- a/cli/domain/local.js
+++ b/cli/domain/local.js
@@ -160,13 +160,18 @@ module.exports = function(){
           localConfig.mocks[mockType] = {};
         }
 
-        if(!localConfig.mocks[mockType].static){
-          localConfig.mocks[mockType].static = {};
+        var pluginType = 'static';
+        if(fs.existsSync(path.resolve(params.targetValue))){
+          pluginType = 'dynamic';
         }
 
-        localConfig.mocks[mockType].static[params.targetName] = params.targetValue;
+        if(!localConfig.mocks[mockType][pluginType]){
+          localConfig.mocks[mockType][pluginType] = {};
+        }
 
-        return fs.writeJson(settings.configFile.src, localConfig, callback);
+        localConfig.mocks[mockType][pluginType][params.targetName] = params.targetValue;
+
+        return fs.writeJson(settings.configFile.src, localConfig, {spaces: 2}, callback);
       });
     },
     package: function(componentPath, minify, callback){
@@ -260,9 +265,9 @@ module.exports = function(){
         function(component, cb){
           // Packaging static files
           packageStaticFiles({
-            componentPath: componentPath, 
-            publishPath: publishPath, 
-            minify: minify, 
+            componentPath: componentPath,
+            publishPath: publishPath,
+            minify: minify,
             ocOptions: component.oc
           }, function(err, res){
             return cb(err, component);

--- a/cli/facade/dev.js
+++ b/cli/facade/dev.js
@@ -99,19 +99,7 @@ module.exports = function(dependencies){
     };
 
     var registerPlugins = function(registry){
-      var mockedPlugins = getMockedPlugins();
-
-      try {
-        if(!_.isEmpty(mockedPlugins)){
-          logger.log(strings.messages.cli.REGISTERING_MOCKED_PLUGINS.yellow);
-          for(var i = 0; i < mockedPlugins.length; i++){
-            logger.log('├── '.green + mockedPlugins[i].name + ' () => ' + mockedPlugins[i].register.execute());
-            registry.register(mockedPlugins[i]);
-          }            
-        }
-      } catch(er){
-        return logger.log(er.red);
-      }
+      var mockedPlugins = getMockedPlugins(logger);
 
       registry.on('request', function(data){
         if(data.errorCode === 'PLUGIN_MISSING_FROM_REGISTRY'){
@@ -138,7 +126,7 @@ module.exports = function(dependencies){
 
       loadDependencies(components, function(dependencies){
         packageComponents(components, function(){
-          
+
           var registry = new oc.Registry({
             local: true,
             discovery: true,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,10 +65,10 @@ oc dev <dirName> [port]
 
 Parameters:
 
-|Name|Description|
-|----|-----------|
-|dirName|The name of the directory to watch, where the components are stored|
-|port|The port where to start a local oc instance. Default 3000|
+|Name|Description|Choices|
+|----|-----------|-------|
+|dirName|The name of the directory to watch, where the components are stored||
+|port|The port where to start a local oc instance. Default 3000||
 
 ##info
 Shows installed components on the current project
@@ -89,10 +89,10 @@ oc init <componentName> [templateType]
 
 Parameters:
 
-|Name|Description|
-|----|-----------|
-|componentName|The name of the component to create|
-|templateType|The component's template type. Options are jade or handlebars (default).|
+|Name|Description|Choices|
+|----|-----------|-------|
+|componentName|The name of the component to create||
+|templateType|The component's template type. Options are jade or handlebars (default).||
 
 ##link
 Links a component in the current project
@@ -105,10 +105,10 @@ oc link <componentName> [componentVersion]
 
 Parameters:
 
-|Name|Description|
-|----|-----------|
-|componentName|The name of the component to link. <oc ls> to see the list of available components|
-|componentVersion|The specific version of the component to link. Default is the latest|
+|Name|Description|Choices|
+|----|-----------|-------|
+|componentName|The name of the component to link. <oc ls> to see the list of available components||
+|componentVersion|The specific version of the component to link. Default is the latest||
 
 ##ls
 Shows the list of the available components for a linked oc registry
@@ -121,9 +121,9 @@ oc ls [registry]
 
 Parameters:
 
-|Name|Description|
-|----|-----------|
-|registry|Specify registry to query|
+|Name|Description|Choices|
+|----|-----------|-------|
+|registry|Specify registry to query||
 
 ##mock
 Allows to mock configuration in order to facilitate local development
@@ -136,14 +136,11 @@ oc mock <targetType> <targetName> <targetValue>
 
 Parameters:
 
-|Name|Description|
-|----|-----------|
-|targetType|The type of item to mock (plugin, command)|
-|targetName|The item to mock|
-|targetValue|The mocked value|
-
-example: `oc mock plugin foo bar` adds a static mock for plugin `foo` to return value `bar`.
-example: `oc mock plugin foo ./bar.js` adds a dynamic mock using file `./bar.js`
+|Name|Description|Choices|
+|----|-----------|-------|
+|targetType|The type of item to mock|plugin|
+|targetName|The item to mock||
+|targetValue|The mocked value (static plugins) or the file to read (dynamic plugins)||
 
 ##preview
 Runs a test page consuming a component
@@ -156,9 +153,9 @@ oc preview <componentHref>
 
 Parameters:
 
-|Name|Description|
-|----|-----------|
-|componentHref|The name of the component to preview|
+|Name|Description|Choices|
+|----|-----------|-------|
+|componentHref|The name of the component to preview||
 
 ##publish
 Publish a component
@@ -171,9 +168,9 @@ oc publish <componentPath>
 
 Parameters:
 
-|Name|Description|
-|----|-----------|
-|componentPath|The path of the component to publish|
+|Name|Description|Choices|
+|----|-----------|-------|
+|componentPath|The path of the component to publish||
 
 ##registry
 Shows, adds, removes oc registries to the current project
@@ -186,10 +183,10 @@ oc registry <command> [parameter]
 
 Parameters:
 
-|Name|Description|
-|----|-----------|
-|command|Action: add, ls, or remove|
-|parameter|Parameter to perform the action|
+|Name|Description|Choices|
+|----|-----------|-------|
+|command|Action: add, ls, or remove|add,ls,remove|
+|parameter|Parameter to perform the action||
 
 ##unlink
 Unlinks a component from the current project
@@ -202,9 +199,9 @@ oc unlink <componentName>
 
 Parameters:
 
-|Name|Description|
-|----|-----------|
-|componentName|The name of the component to unlink. <oc info> to see the list of linked components|
+|Name|Description|Choices|
+|----|-----------|-------|
+|componentName|The name of the component to unlink. <oc info> to see the list of linked components||
 
 ##version
 Shows the cli version
@@ -213,3 +210,4 @@ Usage:
 ```sh
 oc version
 ```
+

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -138,9 +138,12 @@ Parameters:
 
 |Name|Description|
 |----|-----------|
-|targetType|The type of item to mock|
+|targetType|The type of item to mock (plugin, command)|
 |targetName|The item to mock|
 |targetValue|The mocked value|
+
+example: `oc mock plugin foo bar` adds a static mock for plugin `foo` to return value `bar`.
+example: `oc mock plugin foo ./bar.js` adds a dynamic mock using file `./bar.js`
 
 ##preview
 Runs a test page consuming a component
@@ -210,4 +213,3 @@ Usage:
 ```sh
 oc version
 ```
-

--- a/grunt-tasks/support/cli-commands-parser.js
+++ b/grunt-tasks/support/cli-commands-parser.js
@@ -24,11 +24,11 @@ module.exports = {
       }
 
       detailedCommandList += '\n```\n';
-      
+
       if(!!command.options){
-        detailedCommandList += '\n\nParameters:\n\n|Name|Description|\n|----|-----------|\n';
+        detailedCommandList += '\n\nParameters:\n\n|Name|Description|Choices|\n|----|-----------|-------|\n';
         _.forEach(command.options, function(option, optionName){
-          detailedCommandList += '|' + optionName + '|' + option.help + '|\n';
+          detailedCommandList += '|' + optionName + '|' + option.help + '|' + (option.choices || '') + '|\n';
         });
       }
     });

--- a/test/unit/cli-domain-local.js
+++ b/test/unit/cli-domain-local.js
@@ -145,12 +145,12 @@ describe('cli : domain : local', function(){
     });
   });
 
-  describe('when mocking a plugin', function(){
+  describe('when mocking a static plugin', function(){
 
     var data;
     beforeEach(function(done){
       data = initialise();
-      
+
       data.fs.readJson.yields(null, { something: 'hello' });
       data.fs.writeJson.yields(null, 'ok');
 
@@ -165,6 +165,34 @@ describe('cli : domain : local', function(){
           plugins: {
             static: {
               getValue: 'value'
+            }
+          }
+        }
+      });
+    });
+  });
+
+  describe('when mocking a dynamic plugin', function(){
+
+    var data;
+    beforeEach(function(done){
+      data = initialise();
+
+      data.fs.readJson.yields(null, { something: 'hello' });
+      data.fs.existsSync.returns(true);
+      data.fs.writeJson.yields(null, 'ok');
+
+      executeMocking(data.local, 'plugin', 'getValue', './value.js', done);
+    });
+
+    it('should add mock to oc.json', function(){
+      expect(data.fs.writeJson.called).to.be.true;
+      expect(data.fs.writeJson.args[0][1]).to.eql({
+        something: 'hello',
+        mocks: {
+          plugins: {
+            dynamic: {
+              getValue: './value.js'
             }
           }
         }


### PR DESCRIPTION
The file `cli/domain/get-mocked-plugins.js` isn't covered by any tests at the moment.

Will write some new proper tests for it. Just sending the PR so you can have a look @matteofigus 