### PR TITLE
Fix cli crash when `oc dev` reads a broken package.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,7 +57,7 @@ module.exports = function(grunt) {
     fs.writeFileSync(path.join(__dirname, 'client/oc-client.min.js'), compressedClientLibrary);
 
     var Local = require('./cli/domain/local'),
-        local = new Local();
+        local = new Local({ logger: { log: grunt.log.writeln }});
 
     local.package(path.join(__dirname, 'components/oc-client'), function(err, res){
       grunt.log[!!err ? 'error' : 'ok'](!!err ? err : 'Client has been built and packaged');

--- a/cli/domain/get-components-by-dir.js
+++ b/cli/domain/get-components-by-dir.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var fs = require('fs-extra');
+var path = require('path');
+var _ = require('underscore');
+
+module.exports = function(dependencies){
+  var logger = dependencies.logger;
+  return function(componentsDir, callback){
+
+    try {
+      var components = fs.readdirSync(componentsDir).filter(function(file){
+
+        var filePath = path.resolve(componentsDir, file),
+            isDir = fs.lstatSync(filePath).isDirectory(),
+            packagePath = path.join(filePath, 'package.json');
+
+        if(!isDir || !fs.existsSync(packagePath)){
+          return false;
+        }
+
+        var content;
+
+        try {
+          content = fs.readJsonSync(packagePath);
+        }
+        catch(err)
+        {
+          logger.log(('error reading ' + packagePath + ' ' + err.toString()).red);
+          return false;
+        }
+
+        if(!content.oc || !!content.oc.packaged){
+          return false;
+        }
+
+        return true;
+      });
+
+      var fullPathComponents = _.map(components, function(component){
+        return path.resolve(componentsDir, component);
+      });
+
+      callback(null, fullPathComponents);
+
+    } catch(err){
+      return callback(err);
+    }
+  };
+};

--- a/cli/index.js
+++ b/cli/index.js
@@ -9,14 +9,16 @@ var Local = require('./domain/local');
 var Registry = require('./domain/registry');
 var strings = require('../resources');
 
+var logger = {
+  log: console.log,
+  logNoNewLine: function(msg){
+    return process.stdout.write(msg.toString());
+  }
+};
+
 var dependencies = {
-  local: new Local(),
-  logger: {
-    log: console.log,
-    logNoNewLine: function(msg){
-      return process.stdout.write(msg.toString());
-    }
-  },
+  local: new Local({ logger: logger }),
+  logger: logger,
   registry: new Registry()
 };
 

--- a/test/unit/cli-domain-local-get-components-by-dir.js
+++ b/test/unit/cli-domain-local-get-components-by-dir.js
@@ -1,0 +1,126 @@
+'use strict';
+
+var expect = require('chai').expect;
+var injectr = require('injectr');
+var path = require('path');
+var sinon = require('sinon');
+var _ = require('underscore');
+
+var initialise = function(){
+
+  var loggerMock = {
+    log: sinon.stub()
+  };
+
+  var fsMock = {
+    existsSync: sinon.stub(),
+    lstatSync: sinon.stub(),
+    mkdirSync: sinon.spy(),
+    readdirSync: sinon.stub(),
+    readFileSync: sinon.stub(),
+    readJson: sinon.stub(),
+    readJsonSync: sinon.stub(),
+    writeFile: sinon.stub().yields(null, 'ok'),
+    writeJson: sinon.stub().yields(null, 'ok')
+  };
+
+  var pathMock = {
+    extname: path.extname,
+    join: path.join,
+    resolve: function(){
+      return _.toArray(arguments).join('/');
+    }
+  };
+
+  var GetComponentsByDir = injectr('../../cli/domain/get-components-by-dir.js', {
+    'fs-extra': fsMock,
+    path: pathMock
+  }, { __dirname: '' });
+
+  var local = new GetComponentsByDir({ logger: loggerMock });
+
+  return { local: local, fs: fsMock, logger: loggerMock };
+};
+
+var executeComponentsListingByDir = function(local, callback){
+  return local('.', callback);
+};
+
+describe('cli : domain : get-components-by-dir', function(){
+
+  describe('when getting components from dir', function(){
+
+    var error, result;
+    beforeEach(function(done){
+
+      var data = initialise();
+
+      data.fs.readdirSync.onCall(0).returns([
+        'a-component',
+        'a-not-component-dir',
+        'a-file.json',
+        '_package'
+      ]);
+
+      data.fs.lstatSync.onCall(0).returns({ isDirectory: function(){ return true; }});
+      data.fs.existsSync.onCall(0).returns(true);
+      data.fs.readJsonSync.onCall(0).returns({ oc: {}});
+
+      data.fs.lstatSync.onCall(1).returns({ isDirectory: function(){ return true; }});
+      data.fs.existsSync.onCall(1).returns(false);
+
+      data.fs.lstatSync.onCall(2).returns({ isDirectory: function(){ return false; }});
+
+      data.fs.lstatSync.onCall(3).returns({ isDirectory: function(){ return true; }});
+      data.fs.existsSync.onCall(2).returns(true);
+      data.fs.readJsonSync.onCall(1).returns({ oc: { packaged: true }});
+
+      executeComponentsListingByDir(data.local, function(err, res){
+        error = err;
+        result = res;
+        done();
+      });
+    });
+
+    it('should add version to package.json file', function(){
+      expect(result).to.eql(['./a-component']);
+    });
+  });
+
+  describe('when reading a broken package.json', function(){
+
+    var error, result, logger;
+    beforeEach(function(done){
+
+      var data = initialise();
+
+      data.fs.readdirSync.onCall(0).returns([
+        'a-broken-component',
+        'another-component'
+      ]);
+
+      data.fs.lstatSync.onCall(0).returns({ isDirectory: function(){ return true; }});
+      data.fs.existsSync.onCall(0).returns(true);
+      data.fs.readJsonSync.onCall(0).throws(new Error('syntax error: fubar'));
+
+      data.fs.lstatSync.onCall(1).returns({ isDirectory: function(){ return true; }});
+      data.fs.existsSync.onCall(1).returns(true);
+      data.fs.readJsonSync.onCall(1).returns({ oc: { }});
+
+      executeComponentsListingByDir(data.local, function(err, res){
+        error = err;
+        result = res;
+        logger = data.logger;
+        done();
+      });
+    });
+
+    it('should handle the error and continue loading other components', function(){
+      expect(result).to.eql(['./another-component']);
+    });
+
+    it('should log the error', function(){
+      expect(logger.log.called).to.eql(true);
+    });
+  });
+});

--- a/test/unit/cli-facade-dev.js
+++ b/test/unit/cli-facade-dev.js
@@ -9,7 +9,7 @@ describe('cli : facade : dev', function(){
   var logSpy = {},
       DevFacade = require('../../cli/facade/dev'),
       Local = require('../../cli/domain/local'),
-      local = new Local(),
+      local = new Local({ logger: { log: function(){} } }),
       npm = require('npm'),
       devFacade = new DevFacade({ local: local, logger: logSpy });
 

--- a/test/unit/cli-facade-info.js
+++ b/test/unit/cli-facade-info.js
@@ -11,7 +11,7 @@ describe('cli : facade : info', function(){
       Registry = require('../../cli/domain/registry'),
       registry = new Registry(),
       Local = require('../../cli/domain/local'),
-      local = new Local(),
+      local = new Local({ logger: { log: function(){} } }),
       InfoFacade = require('../../cli/facade/info'),
       infoFacade = new InfoFacade({ registry: registry, local: local, logger: logSpy });
 
@@ -32,7 +32,7 @@ describe('cli : facade : info', function(){
   describe('when showing project info', function(){
 
     describe('when the information can\'t be retrieved', function(){
-      
+
       beforeEach(function(){
         setup([{ obj: local, method: 'info', responses: [{err: 'something bad happened'}]}]);
         execute();
@@ -67,7 +67,7 @@ describe('cli : facade : info', function(){
 
       describe('when there are no components linked in the project', function(){
 
-        beforeEach(function(){          
+        beforeEach(function(){
           setup([{ obj: local, method: 'info', responses: [{ res: { registries: ['http://registry.com'], components: {}}}]}]);
           execute();
         });
@@ -83,10 +83,10 @@ describe('cli : facade : info', function(){
 
       describe('when there are components linked in the project', function(){
 
-        beforeEach(function(){     
-          setup([{ 
-            obj: local, 
-            method: 'info', 
+        beforeEach(function(){
+          setup([{
+            obj: local,
+            method: 'info',
             responses: [{
               res: { registries: ['http://registry.com'], components: { 'ghost': '1.X.X', 'hello': '~1.0.0' }}
             }]
@@ -116,7 +116,7 @@ describe('cli : facade : info', function(){
 
         it('should list the components', function(){
           expect(logSpy.log.args[0][0]).to.be.equal('Components linked in project:'.yellow);
-        }); 
+        });
 
         it('should show a message when a component is not found on the registry', function(){
           expect(logSpy.log.args[1][0]).to.include('Not available'.red);

--- a/test/unit/cli-facade-init.js
+++ b/test/unit/cli-facade-init.js
@@ -9,7 +9,7 @@ describe('cli : facade : init', function(){
   var logSpy = {},
       InitFacade = require('../../cli/facade/init'),
       Local = require('../../cli/domain/local'),
-      local = new Local(),
+      local = new Local({ logger: { log: function(){} } }),
       initFacade = new InitFacade({ local: local, logger: logSpy });
 
   var execute = function(componentName, templateType){

--- a/test/unit/cli-facade-link.js
+++ b/test/unit/cli-facade-link.js
@@ -9,7 +9,7 @@ describe('cli : facade : link', function(){
   var logSpy = {},
       LinkFacade = require('../../cli/facade/link'),
       Local = require('../../cli/domain/local'),
-      local = new Local(),
+      local = new Local({ logger: { log: function(){} } }),
       linkFacade = new LinkFacade({ local: local, logger: logSpy });
 
   var execute = function(){
@@ -33,7 +33,7 @@ describe('cli : facade : link', function(){
       it('should show the error', function(){
         expect(logSpy.log.args[0][0]).to.equal('an error!'.red);
       });
-    }); 
+    });
 
     describe('when it succeeds', function(){
 
@@ -41,7 +41,7 @@ describe('cli : facade : link', function(){
         sinon.stub(local, 'link').yields(null, 'yay');
         execute();
       });
-      
+
       afterEach(function(){
         local.link.restore();
       });

--- a/test/unit/cli-facade-mock.js
+++ b/test/unit/cli-facade-mock.js
@@ -9,7 +9,7 @@ describe('cli : facade : mock', function(){
   var logSpy = {},
       MockFacade = require('../../cli/facade/mock'),
       Local = require('../../cli/domain/local'),
-      local = new Local(),
+      local = new Local({ logger: { log: function(){} } }),
       mockFacade = new MockFacade({ local: local, logger: logSpy });
 
   var execute = function(){
@@ -25,7 +25,7 @@ describe('cli : facade : mock', function(){
         sinon.stub(local, 'mock').yields(null, 'ok');
         execute();
       });
-      
+
       afterEach(function(){
         local.mock.restore();
       });

--- a/test/unit/cli-facade-publish.js
+++ b/test/unit/cli-facade-publish.js
@@ -12,7 +12,7 @@ describe('cli : facade : publish', function(){
       Registry = require('../../cli/domain/registry'),
       registry = new Registry(),
       Local = require('../../cli/domain/local'),
-      local = new Local(),
+      local = new Local({ logger: { log: function(){} } }),
       PublishFacade = require('../../cli/facade/publish'),
       publishFacade = new PublishFacade({ registry: registry, local: local, logger: logSpy });
 

--- a/test/unit/cli-facade-unlink.js
+++ b/test/unit/cli-facade-unlink.js
@@ -8,7 +8,7 @@ describe('cli : facade : unlink', function(){
 
   var logSpy = {},
       Local = require('../../cli/domain/local'),
-      local = new Local(),  
+      local = new Local({ logger: { log: function(){} } }),  
       UnlinkFacade = require('../../cli/facade/unlink'),
       unlinkFacade = new UnlinkFacade({ local:local, logger: logSpy });
 
@@ -29,7 +29,7 @@ describe('cli : facade : unlink', function(){
       it('should show the error', function(){
         expect(logSpy.log.args[0][0]).to.equal('an error!'.red);
       });
-    }); 
+    });
 
     describe('when it succeeds', function(){
 


### PR DESCRIPTION
- wrapped the readJsonSync call in a try-catch, log it and then continue loading the other components
- moved getComponentsByDir out into a separate file
- cli/domain/local.js now has a dependency on logger
- added tests to cover

turned out a bit larger than I had intended