### PR TITLE
Gzip static files on package

### DIFF
--- a/cli/domain/package-static-files.js
+++ b/cli/domain/package-static-files.js
@@ -8,6 +8,7 @@ var nodeDir = require('node-dir');
 var path = require('path');
 var uglifyJs = require('uglify-js');
 var _ = require('underscore');
+var gzip = require('../../utils/gzip');
 
 var strings = require('../../resources');
 
@@ -35,8 +36,8 @@ var copyDir = function(params, cb){
   } else {
 
     nodeDir.paths(staticPath, function(err, res){
-      _.forEach(res.files, function(filePath){
-    
+      async.each(res.files, function(filePath, done){
+
         var fileName = path.basename(filePath),
             fileExt = path.extname(filePath).toLowerCase(),
             fileRelativePath = path.relative(staticPath, path.dirname(filePath)),
@@ -53,8 +54,15 @@ var copyDir = function(params, cb){
         } else {
           fs.copySync(filePath, fileDestination);
         }
+
+        if(fileExt === '.js' || fileExt === '.css'){
+          return gzip(fileDestination, fileDestination + '.gz', done);
+        }
+
+        done();
+      }, function(err){
+        cb(err, 'ok');
       });
-      cb(null, 'ok');
     });
   }
 };

--- a/cli/domain/package-template.js
+++ b/cli/domain/package-template.js
@@ -6,6 +6,7 @@ var handlebars = require('handlebars');
 var jade = require('jade');
 var path = require('path');
 var uglifyJs = require('uglify-js');
+var gzip = require('../../utils/gzip');
 
 var hashBuilder = require('../../utils/hash-builder');
 var strings = require('../../resources');
@@ -57,11 +58,16 @@ module.exports = function(params, callback){
     return callback(format('{0} compilation failed - {1}', viewSrc, e));
   }
 
-  fs.writeFile(path.join(params.publishPath, 'template.js'), compiled.view, function(err, res){
-    callback(err, {
-      type: params.ocOptions.files.template.type,
-      hashKey: compiled.hash,
-      src: 'template.js'
+  var destination = path.join(params.publishPath, 'template.js');
+
+  fs.writeFile(destination, compiled.view, function(err, res){
+    if(err){ return callback(err); }
+    gzip(destination, destination + '.gz', function(err){
+      callback(err, {
+        type: params.ocOptions.files.template.type,
+        hashKey: compiled.hash,
+        src: 'template.js'
+      });
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "read": "1.0.7",
     "semver": "5.0.3",
     "stringformat": "0.0.5",
-    "tar.gz": "0.1.1",
+    "tar.gz": "^1.0.2",
     "uglify-js": "2.5.0",
     "underscore": "1.8.1",
     "watch": "0.13.0"

--- a/test/unit/cli-domain-package-static-files.js
+++ b/test/unit/cli-domain-package-static-files.js
@@ -55,7 +55,8 @@ var cleanup = function(){
     },
     'uglify-js': { minify: sinon.stub().returns({
       code: 'this-is-minified'
-    })}
+    })},
+    '../../utils/gzip': sinon.stub().yields(null)
   };
 };
 
@@ -160,6 +161,10 @@ describe('cli : domain : packageStaticFiles', function(){
       it('should copy the file to the right destination', function(){
         expect(mocks['fs-extra'].copySync.args[0][1]).to.equal('/path/to/component/_package/img/file.png');
       });
+
+      it('should not gzip the image', function(){
+        expect(mocks['../../utils/gzip'].called).to.equal(false);
+      });
     });
 
     describe('when copying folder with sub-folders', function(){
@@ -225,6 +230,10 @@ describe('cli : domain : packageStaticFiles', function(){
 
         it('should copy the file to the right destination', function(){
           expect(mocks['fs-extra'].copySync.args[0][1]).to.equal('/path/to/component/_package/js/file.js');
+        });
+
+        it('should gzip the file', function(){
+          expect(mocks['../../utils/gzip'].called).to.equal(true);
         });
       });
 
@@ -292,6 +301,10 @@ describe('cli : domain : packageStaticFiles', function(){
         it('should copy the file to the right destination', function(){
           expect(mocks['fs-extra'].copySync.args[0][1]).to.equal('/path/to/component/_package/css/file.css');
         });
+
+        it('should gzip the file', function(){
+          expect(mocks['../../utils/gzip'].called).to.equal(true);
+        });
       });
 
       describe('when minify=true', function(){
@@ -325,6 +338,10 @@ describe('cli : domain : packageStaticFiles', function(){
 
         it('should save the file to the right destination', function(){
           expect(mocks['fs-extra'].writeFileSync.args[0][0]).to.equal('/path/to/component/_package/css/file.css');
+        });
+
+        it('should gzip the file', function(){
+          expect(mocks['../../utils/gzip'].called).to.equal(true);
         });
       });
 

--- a/test/unit/cli-domain-package-template.js
+++ b/test/unit/cli-domain-package-template.js
@@ -8,6 +8,7 @@ var uglifyJs = require('uglify-js');
 var _ = require('underscore');
 
 var fsMock,
+    gzipMock,
     packageTemplate,
     uglifySpy;
 
@@ -19,6 +20,8 @@ var initialise = function(fs, uglifyStub){
     readFileSync: sinon.stub().returns('file content'),
     writeFile: sinon.stub().yields(null, 'ok')
   }, fs || {});
+
+  gzipMock = sinon.stub().yields(null);
 
   packageTemplate = injectr('../../cli/domain/package-template.js', {
     'fs-extra': fsMock,
@@ -33,7 +36,8 @@ var initialise = function(fs, uglifyStub){
       resolve: function(){
         return _.toArray(arguments).join('/');
       }
-    }
+    },
+    '../../utils/gzip': gzipMock
   });
 };
 
@@ -128,6 +132,10 @@ describe('cli : domain : package-template', function(){
 
       it('should save compiled view', function(){
         expect(fsMock.writeFile.args[0][1]).to.contain('<div>this is a jade view</div>');
+      });
+
+      it('should gzip compiled view', function(){
+        expect(gzipMock.args[0][1]).to.contain('/path/to/component/_package/template.js');
       });
     });
   });

--- a/test/unit/cli-domain-package-template.js
+++ b/test/unit/cli-domain-package-template.js
@@ -135,7 +135,7 @@ describe('cli : domain : package-template', function(){
       });
 
       it('should gzip compiled view', function(){
-        expect(gzipMock.args[0][1]).to.contain('/path/to/component/_package/template.js');
+        expect(gzipMock.args[0][1]).to.contain('template.js.gz');
       });
     });
   });

--- a/utils/gzip.js
+++ b/utils/gzip.js
@@ -1,0 +1,14 @@
+'use strict';
+
+var zlib = require('zlib');
+var fs = require('fs-extra');
+
+module.exports = function(input, output, callback){
+  var gzip = zlib.createGzip();
+  var inp = fs.createReadStream(input);
+  var out = fs.createWriteStream(output);
+  out.on('error', callback);
+  out.on('finish', callback);
+  inp.on('error', callback);
+  inp.pipe(gzip).pipe(out);
+};


### PR DESCRIPTION
As per #153 (and #138), this code will identify static assets (css, js, template) when packaging and create gzipped copies alongside.

Just thought I'd send the PR because it complements #153 quite nicely.

Maybe we want to disable the behaviour by default for now (control it from a switch in the package.json). See what you think.