### PR TITLE
should have an explicit dep on phantom

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "karma-sinon": "1.0.4",
     "load-grunt-tasks": "0.6.0",
     "mocha": "2.2.4",
+    "phantomjs": "^1.9.19",
     "sinon": "1.14.1"
   },
   "dependencies": {


### PR DESCRIPTION
when installing with npm 3 (or higher) it doesn't resolve the peer-dependency from karma-phantomjs-launcher so we need to specify it explicitly.