### PR TITLE
Npm ignore to avoid publishing unuseful stuff

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+grunt-tasks
+test
+.jshintrc
+.travis.yml
+appveyor.yml
+Gruntfile.js


### PR DESCRIPTION
So that installing OC is quicker