### PR TITLE
Adding user-agent to node oc-client

### DIFF
--- a/client/src/sanitiser.js
+++ b/client/src/sanitiser.js
@@ -1,5 +1,8 @@
 'use strict';
 
+var format = require('stringformat');
+
+var packageInfo = require('../package');
 var _ = require('./utils/helpers');
 
 var lowerHeaderKeys = function(headers){
@@ -26,9 +29,18 @@ module.exports = {
       options = {};
     }
 
+    var defaultUserAgent = format('oc-client-{0}/{1}-{2}-{3}',
+                                  packageInfo.version,
+                                  process.version,
+                                  process.platform,
+                                  process.arch);
+
     options = options || {};
+    
     options.headers = lowerHeaderKeys(options.headers);
     options.headers.accept = 'application/vnd.oc.unrendered+json';
+    options.headers['user-agent'] = options.headers['user-agent'] || defaultUserAgent;
+
     options.timeout = options.timeout || 5;
     options.container = (options.container === true) ?  true : false;
     options.renderInfo = (options.renderInfo === false) ? false : true;

--- a/test/unit/client-sanitiser.js
+++ b/test/unit/client-sanitiser.js
@@ -23,7 +23,7 @@ describe('client : sanitiser', function(){
 
       var result = sanitiser.sanitiseGlobalRenderOptions({}, {});
 
-      it('set oc-client user-agent', function(){
+      it('should set oc-client user-agent', function(){
         expect(result.headers['user-agent']).to.equal('oc-client-1.2.3/v0.10.40-darwin-x64');
       });
     });

--- a/test/unit/client-sanitiser.js
+++ b/test/unit/client-sanitiser.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var expect = require('chai').expect;
+var injectr = require('injectr');
+
+describe('client : sanitiser', function(){
+
+  var sanitiser = injectr('../../client/src/sanitiser.js', {
+    '../package': { 
+      version: '1.2.3'
+    }
+  }, { process: 
+    {
+      version: 'v0.10.40',
+      platform: 'darwin',
+      arch: 'x64'
+    }
+  });
+
+  describe('when sanitising global rendering options', function(){
+
+    describe('when user-agent not already set', function(){
+
+      var result = sanitiser.sanitiseGlobalRenderOptions({}, {});
+
+      it('set oc-client user-agent', function(){
+        expect(result.headers['user-agent']).to.equal('oc-client-1.2.3/v0.10.40-darwin-x64');
+      });
+    });
+  });
+});


### PR DESCRIPTION
The [sanitiser](https://github.com/opentable/oc/blob/master/client/src/components-renderer.js#L20) in the client sanitises the request data before making OC registry requests. 

Extending the request with the clients' user-agent allows OC registry's maintainers to have some insights about consumers. (We already do this with the [CLI](https://github.com/opentable/oc/blob/master/cli/domain/registry.js#L26-L30))