### PR TITLE
Return null when there's no error in renderComponents

### DIFF
--- a/client/src/components-renderer.js
+++ b/client/src/components-renderer.js
@@ -35,13 +35,23 @@ module.exports = function(config, renderTemplate){
       renderComponents(toDo, options, function(){
         processClientReponses(toDo, options, function(){
           var errors = [], 
-              results = [];
+              results = [],
+              hasErrors = false;
         
           _.each(toDo, function(action){
+            if(action.result.error) {
+              hasErrors = true;
+            }
+
             errors.push(action.result.error);
             results.push(action.result.html);
           });
-          callback(errors, results);
+
+          if(hasErrors) {
+            callback(errors, results);
+          } else {
+            callback(null, results);
+          }
         });
       });
     });

--- a/client/src/components-renderer.js
+++ b/client/src/components-renderer.js
@@ -43,7 +43,7 @@ module.exports = function(config, renderTemplate){
               hasErrors = true;
             }
 
-            errors.push(action.result.error);
+            errors.push(action.result.error || null);
             results.push(action.result.html);
           });
 

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -34,7 +34,11 @@ module.exports = function(conf){
         version: options.version,
         parameters: options.parameters || options.params
       }], options, function(errors, results){
-        callback(errors[0], results[0]);
+        if(errors) {
+          return callback(errors[0], results[0]);
+        }
+
+        callback(null, results[0]);
       });
     },
     renderComponents: function(components, options, callback){

--- a/test/acceptance/client.js
+++ b/test/acceptance/client.js
@@ -48,12 +48,14 @@ describe('The node.js OC client', function(){
     describe('when rendering 2 components', function(){
       describe('when rendering both on the server-side', function(){
         var $components;
+        var $errs;
         before(function(done){
           client.renderComponents([{
             name: 'hello-world'
           }, {
             name: 'no-containers'
           }], { container: false, renderInfo: false }, function(err, html){
+            $errs = err;
             $components = {
               'hello-world': html[0],
               'no-containers': html[1]
@@ -65,6 +67,10 @@ describe('The node.js OC client', function(){
         it('should return rendered contents', function(){
           expect($components['hello-world']).to.equal('Hello world!');
           expect($components['no-containers']).to.equal('Hello world!');
+        });
+        
+        it('should return null errors', function () {
+          expect($errs).to.be.null;
         });
       });
 
@@ -114,6 +120,25 @@ describe('The node.js OC client', function(){
 
         it('should return browser oc tag for unrendered component', function(){
           expect($components['no-containers'].attr('href')).to.equal('http://localhost:3030/no-containers');
+        });
+      });
+
+      describe('when there\'s error in one of them', function(){
+        var $errs;
+        before(function(done){
+          client.renderComponents([{
+            name: 'hello-world-i-dont-exist'
+          }, {
+            name: 'no-containers'
+          }], { container: false, renderInfo: false }, function(err, html){
+            $errs = err;
+            done();
+          });
+        });
+
+        it('should return an error for the component with error', function(){
+          expect($errs[0]).to.not.be.null;
+          expect($errs[1]).to.be.null;
         });
       });
     });


### PR DESCRIPTION
Partially fixes: https://github.com/opentable/oc/issues/191
When rendering multiple components and there's no errors client will now return `null` instead of array of `undefined`.
Also if there is no error for given component, but there are errors for other components it will now return `null` for this component instead of `undefined`.