### PR TITLE
Have optional callbacks in CLI functions

### DIFF
--- a/cli/facade/init.js
+++ b/cli/facade/init.js
@@ -2,6 +2,7 @@
 
 var colors = require('colors/safe');
 var format = require('stringformat');
+var _ = require('underscore');
 
 var strings = require('../../resources/index');
 
@@ -10,7 +11,10 @@ module.exports = function(dependencies){
   var local = dependencies.local,
       logger = dependencies.logger;
 
-  return function(opts){
+  return function(opts, callback){
+
+    callback = callback || _.noop;
+
     var componentName = opts.componentName,
         templateType = opts.templateType,
         errors = strings.errors.cli;
@@ -25,10 +29,12 @@ module.exports = function(dependencies){
           err = errors.TEMPLATE_TYPE_NOT_VALID;
         }
 
-        logger.log(format(colors.red(errors.INIT_FAIL), err));
+        logger.log(colors.red(format(errors.INIT_FAIL, err)));
       } else {
-        logger.log(format(colors.green(strings.messages.cli.COMPONENT_INITED), componentName));
+        logger.log(colors.green(format(strings.messages.cli.COMPONENT_INITED, componentName)));
       }
+      
+      callback(err, componentName);
     });
   };
 };

--- a/cli/facade/mock.js
+++ b/cli/facade/mock.js
@@ -2,6 +2,7 @@
 
 var colors = require('colors/safe');
 var format = require('stringformat');
+var _ = require('underscore');
 
 var strings = require('../../resources/index');
 
@@ -10,9 +11,13 @@ module.exports = function(dependencies){
   var local = dependencies.local,
       logger = dependencies.logger;
 
-  return function(opts){
+  return function(opts, callback){
+
+    callback = callback || _.noop;
+
     local.mock(opts, function(err, res){
-      return logger.log(colors.green(format(strings.messages.cli.MOCKED_PLUGIN, opts.targetName, opts.targetValue)));
+      logger.log(colors.green(format(strings.messages.cli.MOCKED_PLUGIN, opts.targetName, opts.targetValue)));
+      callback(err, res);
     });
   };
 };

--- a/cli/facade/preview.js
+++ b/cli/facade/preview.js
@@ -18,7 +18,7 @@ module.exports = function(dependencies){
     registry.getComponentPreviewUrlByUrl(opts.componentHref, function(err, href){
       if(err){ 
         logger.log(colors.red(strings.errors.cli.COMPONENT_HREF_NOT_FOUND));
-        return callback(err);
+        return callback(strings.errors.cli.COMPONENT_HREF_NOT_FOUND);
       }
       opn(href);
       callback(null, href);

--- a/cli/facade/preview.js
+++ b/cli/facade/preview.js
@@ -2,6 +2,7 @@
 
 var colors = require('colors/safe');
 var opn = require('opn');
+var _ = require('underscore');
 
 var strings = require('../../resources/index');
 
@@ -10,10 +11,17 @@ module.exports = function(dependencies){
   var logger = dependencies.logger,
       registry = dependencies.registry;
 
-  return function(opts){
+  return function(opts, callback){
+
+    callback = callback || _.noop;
+
     registry.getComponentPreviewUrlByUrl(opts.componentHref, function(err, href){
-      if(err){ return logger.log(colors.red(strings.errors.cli.COMPONENT_HREF_NOT_FOUND)); }
+      if(err){ 
+        logger.log(colors.red(strings.errors.cli.COMPONENT_HREF_NOT_FOUND));
+        return callback(err);
+      }
       opn(href);
+      callback(null, href);
     });
   };
 };

--- a/cli/facade/publish.js
+++ b/cli/facade/publish.js
@@ -127,10 +127,7 @@ module.exports = function(dependencies){
           putComponentToRegistry({ route: componentRoute, path: compressedPackagePath}, next);
         }, function(err){
           local.cleanup(compressedPackagePath, function(err2, res){
-            if(err){
-              return callback(err);
-            }
-
+            if(err){ return callback(err); }
             callback(err2, res);
           });
         });

--- a/cli/facade/registry.js
+++ b/cli/facade/registry.js
@@ -17,30 +17,50 @@ module.exports = function(dependencies){
     warn: function(msg){ return logger.log(colors.yellow(msg)); }
   };
 
-  return function(opts){
+  return function(opts, callback){
+
+    callback = callback || _.noop;
+    
     if(opts.command === 'ls'){
       registry.get(function(err, registries){
         if(err){
-          return log.err(format(strings.errors.generic, err));
+          log.err(format(strings.errors.generic, err));
+          return callback(err);
         } else {
           log.warn(strings.messages.cli.REGISTRY_LIST);
 
           if(registries.length === 0){
-            log.err(strings.errors.cli.REGISTRY_NOT_FOUND);
+            err = strings.errors.cli.REGISTRY_NOT_FOUND;
+            log.err(err);
+            return callback(err);
           }
 
           _.forEach(registries, function(registryLocation){
             log.ok(registryLocation);       
           });
+
+          callback(null, registries);
         }
       });
     } else if(opts.command === 'add'){
       registry.add(opts.parameter, function(err, res){
-        return err ? log.err(err) : log.ok(strings.messages.cli.REGISTRY_ADDED);
+        if(err){
+          log.err(err);
+          return callback(err);
+        }
+
+        log.ok(strings.messages.cli.REGISTRY_ADDED);
+        callback(null, 'ok');
       });
     } else if(opts.command === 'remove'){
       registry.remove(opts.parameter, function(err, res){
-        return err ? log.err(err) : log.ok(strings.messages.cli.REGISTRY_REMOVED);
+        if(err){
+          log.err(err);
+          return callback(err);
+        }
+
+        log.ok(strings.messages.cli.REGISTRY_REMOVED);
+        callback(null, 'ok');
       });
     }
   };

--- a/test/unit/cli-facade-publish.js
+++ b/test/unit/cli-facade-publish.js
@@ -128,7 +128,7 @@ describe('cli : facade : publish', function(){
               });
 
               it('should publish to all registries', function(){
-                sinon.stub(registry, 'putComponent').yields('blabla');
+                sinon.stub(registry, 'putComponent').yields(null, 'ok');
                 execute();
                 registry.putComponent.restore();
 


### PR DESCRIPTION
This allows facades to be used outside of CLI context, for example to be wrapped inside grunt and gulp plugins. This is required in order to feature complete the `grunt-oc` plugin.