### PR TITLE
add "getRepositoryUrl" in order to support repository package.json property as object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,25 +3,24 @@ language: node_js
 matrix:
   include:
     - node_js: "0.10"
-      env: TEST_COMMAND=test-with-sauce
+      env: SAUCE=true
     - node_js: "0.12"
-      env: TEST_COMMAND=test
     - node_js: "iojs"
-      env: TEST_COMMAND=test
     - node_js: "4"
-      env: TEST_COMMAND=test
     - node_js: "5"
-      env: TEST_COMMAND=test
 
 before_script:
 - npm install -g grunt-cli
 
-script: grunt $TEST_COMMAND
+script: 
+  - grunt test
+  - "[ $SAUCE == false ] || [ $TRAVIS_SECURE_ENV_VARS == false ] || grunt sauce"
 
 notifications:
   email: false
 
 env:
   global:
+  - SAUCE=false
   - secure: OUooygPgokU2pa5FmVKb5tEQ+NjrUS7vr2al2MYqQDi7VOViOkKiP+1TMKDaPEo3+H3BQlsRd/HxItSCucg5Wy+45pMsTnYgR0Lsp2zmcuHmY67EPOM3B6bdCyPtB5VokrpO3O+uBTtMPAKS/sQq62gKV5Xq/K1t5CQ31EgfCd4=
   - secure: P/+5dvk3zwkDnUmNCEX8fgNkLAQ5s6j+dR4h3Zn5UJBBUKSZaz1QbfEX+uZ5Rn4l4aRGdvG2PGStySiS/MHmPKhWJfMMEkSFjERLUF07U2gLSkn1UOQeh0zBWIb5TehwIuuTNPmOoSE/7xgmXwF83Dq8ALjDCmo6VrtoZes9E2g=

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,6 @@ module.exports = function(grunt){
   grunt.registerTask('test-local', ['jshint:all', 'mochaTest:unit', 'mochaTest:acceptance', 'karma:local']);
   grunt.registerTask('test-local-silent', ['jshint:all', 'mochaTest:silent', 'karma:local']);
   grunt.registerTask('test', ['jshint:all', 'mochaTest:unit', 'mochaTest:acceptance']);
-  grunt.registerTask('test-with-sauce', ['test', 'sauce']);
   grunt.registerTask('git-stage', [
     'gitadd:versionFiles',
     'gitcommit:version',

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Contributors:
 * [@char1e5](https://github.com/char1e5)
 * [@federicomaffei](https://github.com/federicomaffei)
 * [@jankowiakmaria](https://github.com/jankowiakmaria)
+* [@mattiaerre](https://github.com/mattiaerre)
 * [@pbazydlo](https://github.com/pbazydlo)
 * [@stevejhiggs](https://github.com/stevejhiggs)
 * [@todd](https://github.com/todd)

--- a/registry/routes/component-info.js
+++ b/registry/routes/component-info.js
@@ -29,7 +29,17 @@ module.exports = function(repository){
             return param.example;
           });
         }
-                
+
+        component.getRepositoryUrl = function() {
+          if (typeof this.repository === 'object') {
+            if (this.repository.url)
+              return this.repository.url;
+          }
+          if (typeof this.repository === 'string')
+            return this.repository;
+          return null;
+        }
+
         return res.render('component-info', {
           component: component,
           dependencies: _.keys(component.dependencies),

--- a/registry/routes/component-info.js
+++ b/registry/routes/component-info.js
@@ -32,13 +32,15 @@ module.exports = function(repository){
 
         component.getRepositoryUrl = function() {
           if (typeof this.repository === 'object') {
-            if (this.repository.url)
+            if (this.repository.url) {
               return this.repository.url;
+            }
           }
-          if (typeof this.repository === 'string')
+          if (typeof this.repository === 'string') {
             return this.repository;
+          }
           return null;
-        }
+        };
 
         return res.render('component-info', {
           component: component,

--- a/registry/routes/component-info.js
+++ b/registry/routes/component-info.js
@@ -31,12 +31,12 @@ module.exports = function(repository){
         }
 
         component.getRepositoryUrl = function() {
-          if (typeof this.repository === 'object') {
+          if (_.isObject(this.repository)) {
             if (this.repository.url) {
               return this.repository.url;
             }
           }
-          if (typeof this.repository === 'string') {
+          if (_.isString(this.repository)) {
             return this.repository;
           }
           return null;

--- a/registry/views/component-info.jade
+++ b/registry/views/component-info.jade
@@ -17,7 +17,7 @@ block content
         span(class='component-state-' + component.oc.state.toLowerCase())= component.oc.state
 
   h3 Component Info
-  +property('Repository', component.repository || 'not available', !!component.repository)
+  +property('Repository', component.getRepositoryUrl() || 'not available', !!component.getRepositoryUrl())
   +property('Author', component.author || 'not available')
   +property('Publish date', new Date(component.oc.date) || 'not available')
   +property('Publish agent', ('OC CLI ' + component.oc.version) || 'not available')


### PR DESCRIPTION
# Description

As per the npm documentation https://docs.npmjs.com/files/package.json#repository the **repository** property inside the package.json file should be an object like the following:

``
{
  "type": "git",
  "url": "https://github.com/npm/npm.git"
}
``

I added a **getRepositoryUrl** method against the component object that returns:

- the content of the **url** property if repository is of type object
- the content of the **repository** property itself if repository is of type string (for backwards compatibility)
- **null** otherwise

then in the view (the partial .jade file) the above method is used instead of the property itself.