### PR TITLE
When data is undefined, registry should 500

### DIFF
--- a/registry/routes/helpers/get-component.js
+++ b/registry/routes/helpers/get-component.js
@@ -99,7 +99,8 @@ module.exports = function(conf, repository){
         if(componentCallbackDone){ return; }
         componentCallbackDone = true;
 
-        if(!!err){
+        if(!!err || !data){
+          err = err || new Error(strings.errors.registry.DATA_OBJECT_IS_UNDEFINED);
           return callback({
             status: 500,
             response: {

--- a/resources/index.js
+++ b/resources/index.js
@@ -34,6 +34,7 @@ module.exports = {
       CONFIGURATION_ROUTES_HANDLER_MUST_BE_FUNCTION: 'Registry configuration is not valid: handler should be a function',
       CONFIGURATION_ROUTES_NOT_VALID: 'Registry configuration is not valid: each route should contain route, method and handler',
       CONFIGURATION_ROUTES_MUST_BE_ARRAY: 'Registry configuration is not valid: routes must be an array',
+      DATA_OBJECT_IS_UNDEFINED: 'data object is undefined',
       DEPENDENCY_NOT_FOUND: 'Component is trying to use unavailable dependencies: {0}',
       DEPENDENCY_NOT_FOUND_CODE: 'DEPENDENCY_MISSING_FROM_REGISTRY',
       LOCAL_PUBLISH_NOT_ALLOWED: 'Components can\'t be published to local repository',

--- a/test/fixtures/mocked-components/index.js
+++ b/test/fixtures/mocked-components/index.js
@@ -6,5 +6,6 @@ module.exports = {
   'error-component': require('./error'),
   'npm-component': require('./npm'),
   'plugin-component': require('./plugin'),
-  'timeout-component': require('./timeout')
+  'timeout-component': require('./timeout'),
+  'undefined-component': require('./undefined')
 };

--- a/test/fixtures/mocked-components/undefined.js
+++ b/test/fixtures/mocked-components/undefined.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  package: {
+    name: 'undefined-component',
+    version: '1.0.0',
+    oc: {
+      container: false,
+      renderInfo: false,
+      files: {
+        template: {
+          type: 'jade',
+          hashKey: 'undefined12345',
+          src: 'template.js'
+        },
+        dataProvider: {
+          type: 'node.js',
+          hashKey: 'undefinedserver12345',
+          src: 'server.js'
+        }
+      }
+    }
+  },
+  data: '"use strict";module.exports.data=function(t,u){u(null);};',
+  view: 'var oc=oc||{};oc.components=oc.components||{},oc.components["undefined12345"]' +
+        '=function(){var o=[];return o.push("<div>hello</div>"),o.join("")};'
+};

--- a/test/unit/registry-routes-component.js
+++ b/test/unit/registry-routes-component.js
@@ -54,6 +54,32 @@ describe('registry : routes : component', function(){
     });
   });
 
+  describe('when getting a component with a server.js that returns undefined data', function(){
+
+    before(function(){
+      initialise(mockedComponents['undefined-component']);
+      componentRoute = new ComponentRoute({}, mockedRepository);
+
+      componentRoute({
+        headers: {},
+        params: { componentName: 'undefined-component' }
+      }, {
+        conf: {
+          baseUrl: 'http://components.com/'
+        },
+        json: resJsonStub
+      });
+    });
+
+    it('should return 500 status code', function(){
+      expect(resJsonStub.args[0][0]).to.be.equal(500);
+    });
+
+    it('should respond with error message for undefined data', function(){
+      expect(resJsonStub.args[0][1].error).to.equal('Component execution error: data object is undefined');
+    });
+  });
+
   describe('when getting a component with server.js execution errors', function(){
 
     before(function(){


### PR DESCRIPTION
This happens when a component calls a callback without an error, but also without the data object. 
At the moment, in some scenarios, the registry just times-out.

When a view doesn't require a view-model, either an empty object should be called-back as result, or a component should have an empty data field in its `package.json` (to declare it doesn't require any logic to work).

Example:
```js
module.exports.data = function(cx, cb){
  var data;
  cb(null);
};
```