### PR TITLE
github api request-limit fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,10 +15,16 @@ When preparing a pull request, ensure all the tests pass locally running `grunt 
 
 ### Publishing new version to npm
 
-You need to be enabled for doing this.
-* `master` should be all green. If not, make it green first.
-* git checkout master
-* git pull
+You need to have access to master and enabled to publish to npm.
+
+* create a github authkey via
+  * run `[sudo] npm i -g github-changes`
+  * run `github-changes -o opentable -r oc -a`
+  * login with github credentials to generate a github auth key + store it safely locally
+  * stash the changes with `git stash`
+* `master` should be all green. If not, make it green first and the get to it
+  * `git checkout master`
+  * `git pull`
 * Run `grunt version:<versionType>` for new version.
   * While on 0.X.X (not stable):
     * `grunt version:patch` for bugfixes, new features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,6 @@ $ [sudo] npm i -g github-changes
 $ github-changes -o opentable -r oc -a
 $ git stash
 
-
 # master should be all green. If not, make it green first and the get to it
 $ git checkout master
 $ git pull
@@ -33,11 +32,24 @@ $ git pull
 #     grunt version:patch for bugfixes, new features
 #     grunt version:minor for all breaking changes
 #     grunt version:major NOT YET. Still need to define milestones for 1.0.0.
-
 $ grunt version:patch
 
 $ git push --follow-tags
 $ [sudo] npm publish .
+```
+
+To publish the node.js client
+
+```sh
+# Run `grunt clientVersion:<versionType>` for new version.
+#   While on 0.X.X (not stable):
+#     grunt clientVersion:patch for bugfixes
+#     grunt clientVersion:minor for new features
+#     grunt clientVersion:major for breaking changes
+$ grunt clientVersion:patch
+
+$ git push
+$ [sudo] npm publish client/
 ```
 
 ## Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,21 +17,28 @@ When preparing a pull request, ensure all the tests pass locally running `grunt 
 
 You need to have access to master and enabled to publish to npm.
 
-* create a github authkey via
-  * run `[sudo] npm i -g github-changes`
-  * run `github-changes -o opentable -r oc -a`
-  * login with github credentials to generate a github auth key + store it safely locally
-  * stash the changes with `git stash`
-* `master` should be all green. If not, make it green first and the get to it
-  * `git checkout master`
-  * `git pull`
-* Run `grunt version:<versionType>` for new version.
-  * While on 0.X.X (not stable):
-    * `grunt version:patch` for bugfixes, new features
-    * `grunt version:minor` for all breaking changes
-    * `grunt version:major` NOT YET. Still need to define milestones for 1.0.0.
-* git push --follow-tags
-* [sudo] npm publish .
+```sh
+# create a github authkey
+$ [sudo] npm i -g github-changes
+$ github-changes -o opentable -r oc -a
+$ git stash
+
+
+# master should be all green. If not, make it green first and the get to it
+$ git checkout master
+$ git pull
+
+# Run `grunt version:<versionType>` for new version.
+#   While on 0.X.X (not stable):
+#     grunt version:patch for bugfixes, new features
+#     grunt version:minor for all breaking changes
+#     grunt version:major NOT YET. Still need to define milestones for 1.0.0.
+
+$ grunt version:patch
+
+$ git push --follow-tags
+$ [sudo] npm publish .
+```
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ When preparing a pull request, ensure all the tests pass locally running `grunt 
 You need to have access to master and enabled to publish to npm.
 
 ```sh
-# create a github authkey
+# create a github authkey (do this just once)
 $ [sudo] npm i -g github-changes
 $ github-changes -o opentable -r oc -a
 $ git stash

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,13 +2,15 @@
 
 var customTasks = {
   build: require('./grunt-tasks/support/task-build'),
+  clientVersion: require('./grunt-tasks/support/task-client-version'),
   generateCliDoc: require('./grunt-tasks/support/task-generate-cli-doc'),
   version: require('./grunt-tasks/support/task-version')
 };
 
 module.exports = function(grunt){
 
-  var taskObject = { pkg: grunt.file.readJSON('package.json') };
+  var taskObject = { pkg: grunt.file.readJSON('package.json') },
+      clientPkg = grunt.file.readJSON('./client/package.json');
 
   grunt.file.expand('grunt-tasks/*.js', '!grunt-tasks/_*.js').forEach(function(file) {
     var name = file.split('/');
@@ -24,16 +26,23 @@ module.exports = function(grunt){
   grunt.registerTask('test-local', ['jshint:all', 'mochaTest:unit', 'mochaTest:acceptance', 'karma:local']);
   grunt.registerTask('test-local-silent', ['jshint:all', 'mochaTest:silent', 'karma:local']);
   grunt.registerTask('test', ['jshint:all', 'mochaTest:unit', 'mochaTest:acceptance']);
+
   grunt.registerTask('git-stage', [
-    'gitadd:versionFiles',
+    'gitadd:all',
     'gitcommit:version',
     'gittag:addtag',
     'githubChanges',
     'gitadd:changelog',
     'gitcommit:changelog'
   ]);
+  
+  grunt.registerTask('git-stage-client', [
+    'gitadd:all',
+    'gitcommit:client',
+  ]);
 
   grunt.registerTask('build', 'Builds and minifies the oc-client component', customTasks.build(grunt, taskObject));
   grunt.registerTask('generate-cli-doc', 'Automatically updates the cli.md file', customTasks.generateCliDoc);
-  grunt.registerTask('version', 'Does the version upgrade', customTasks.version(grunt, taskObject));
+  grunt.registerTask('version', 'Upgrades the library', customTasks.version(grunt, taskObject));
+  grunt.registerTask('client-version', 'Upgrades the node.js client', customTasks.clientVersion(grunt, taskObject));
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,13 +36,10 @@ module.exports = function(grunt){
     'gitcommit:changelog'
   ]);
   
-  grunt.registerTask('git-stage-client', [
-    'gitadd:all',
-    'gitcommit:client',
-  ]);
+  grunt.registerTask('git-stage-client', ['gitadd:all', 'gitcommit:client']);
 
   grunt.registerTask('build', 'Builds and minifies the oc-client component', customTasks.build(grunt, taskObject));
   grunt.registerTask('generate-cli-doc', 'Automatically updates the cli.md file', customTasks.generateCliDoc);
   grunt.registerTask('version', 'Upgrades the library', customTasks.version(grunt, taskObject));
-  grunt.registerTask('client-version', 'Upgrades the node.js client', customTasks.clientVersion(grunt, taskObject));
+  grunt.registerTask('client-version', 'Upgrades the node.js client', customTasks.clientVersion(grunt, clientPkg));
 };

--- a/grunt-tasks/gitadd.js
+++ b/grunt-tasks/gitadd.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  versionFiles: {
+  all: {
     files: {
       src: ['.']
     }

--- a/grunt-tasks/gitcommit.js
+++ b/grunt-tasks/gitcommit.js
@@ -1,6 +1,14 @@
 'use strict';
 
 module.exports = {
+  client: {
+    options: {
+      message: 'oc-client <%= version %>'
+    },
+    files: {
+      src: ['.']
+    }
+  },
   version: {
     options: {
       message: '<%= version %>'

--- a/grunt-tasks/support/task-client-version.js
+++ b/grunt-tasks/support/task-client-version.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var fs = require('fs-extra');
+var path = require('path');
+var semver = require('semver');
+
+module.exports = function(grunt, pkg){
+  return function(versionType){
+
+    pkg.version = semver.inc(pkg.version, versionType);
+    grunt.config.set('version', pkg.version);
+
+    grunt.log.ok('Client package version upgrading to: ' + pkg.version);
+
+    fs.writeJsonSync(path.join(__dirname, '../../client/package.json'), pkg, {spaces: 2});
+
+    grunt.task.run([
+      'test-local-silent',
+      'build',
+      'git-stage-client'
+    ]);
+  };
+};


### PR DESCRIPTION
When generating the new changelog, you need to be logged in into github or most likely you will hit the api rate limit. This should do, while we integrate something better into the grunt pipeline.

This PR also includes the code for publishing the node.js client.

/cc @pbazydlo @jankowiakmaria @andyroyle 