### PR TITLE
Removed ace editor + added Accept-Language box

### DIFF
--- a/registry/views/component-info.jade
+++ b/registry/views/component-info.jade
@@ -69,8 +69,14 @@ block content
     | You can edit the following area and then 
     a.refresh-preview(href="#refresh") refresh 
     | to apply the change into the preview window.
-  #editor
-    | &lt;oc-component href=&quot;#{href + component.name + '/' + component.version + '/' + sandBoxDefaultQs}&quot;&gt;&lt;/oc-component&gt;
+
+  div.field
+    p Component's href:
+  textarea.search#href(placeholder="Insert component href here") #{href + component.name + '/' + component.version + '/' + sandBoxDefaultQs}
+
+  div.field
+    p Accept-Language header:
+  input.search#lang(value="*")
 
   h3
     | Preview 
@@ -78,20 +84,7 @@ block content
   iframe.preview(src='~preview/' + sandBoxDefaultQs)
 
 block scripts
-  script(src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/ace.min.js")
-  script(src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/mode-html.js")
-  script(src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/theme-github.js")
   script.
-    var editor;
-    if(!!window.ace){
-      editor = ace.edit('editor');
-      editor.container.style.opacity = '';
-      editor.session.setMode('ace/mode/html');
-      editor.setAutoScrollEditorIntoView(true);
-      editor.setOption('maxLines', 40);
-      editor.setTheme('ace/theme/github');
-    }
-
     var oc = oc || {};
     oc.cmd = oc.cmd || [];
 
@@ -101,23 +94,23 @@ block scripts
       });
 
       $('.refresh-preview').click(function(){
-        if(!!editor){
-          var code = editor.getValue(),
-              splitted = $(code).attr('href').split('?'),
-              url = splitted[0];
 
-          if(url.slice(-1) !== '/'){
-            url += '/';
-          }
+        var splitted = $('#href').val().split('?'),
+            url = splitted[0],
+            lang = $('#lang').val();
 
-          url = url.replace('http\:\/\/', '\/\/').replace('https\:\/\/', '\/\/') + '~preview';
-
-          if(splitted.length > 1){
-            url += '/?' + splitted[1];
-          }
-
-          $('.preview').attr('src', url);
+        if(url.slice(-1) !== '/'){
+          url += '/';
         }
+
+        url = url.replace('http\:\/\/', '\/\/').replace('https\:\/\/', '\/\/');
+        url += '~preview/?__ocAcceptLanguage=' + lang + '&';
+
+        if(splitted.length > 1){
+          url += splitted[1];
+        }
+
+        $('.preview').attr('src', url);
 
         return false;
       });

--- a/registry/views/css.jade
+++ b/registry/views/css.jade
@@ -39,12 +39,6 @@ style.
     width: 100%;
   }
 
-  #editor {
-    height: 200px;
-    float: left;
-    width: 100%;
-  }
-
   .preview {
     height: 300px;
     border: 1px solid #000;
@@ -169,6 +163,10 @@ style.
     margin-bottom: 10px;
     font-size: 20px;
     padding: 10px;
+  }
+
+  #href {
+    height: 30px;
   }
 
   .states {


### PR DESCRIPTION
* Removed ace editor and replaced with good old textboxes (it is anyway kind of broken, loads a lot of extra javascript, doesn't add any value)
* Added the Accept-Language field in order to test multi-lingual components

To test:
* checkout the branch locally
* go to a folder of components
* load `oc dev` using local oc, example `node ../oc/oc-cli.js dev . 3030`
* have fun

Can anyone have a look?
Thanks