### PR TITLE
Empty string should be a valid string parameter

### DIFF
--- a/registry/domain/validators/component-parameters.js
+++ b/registry/domain/validators/component-parameters.js
@@ -5,28 +5,18 @@ var _ = require('underscore');
 
 var strings = require('../../../resources');
 
-var validate = {
-  booleanParameter: function(booleanParameter){
-    return _.isBoolean(booleanParameter);
-  },
+var validateParameter = function(parameter, expectedType){
+  var expected = expectedType.toLowerCase();
 
-  numberParameter: function(numberParameter){
-    return _.isNumber(numberParameter);
-  },
-
-  parameter: function(parameter, expectedType){
-    var expected = expectedType.toLowerCase();
-
-    if(_.contains(['string', 'boolean', 'number'], expected)){
-      return validate[expected + 'Parameter'](parameter);
-    }
-
-    return false;
-  },
-
-  stringParameter: function(stringParameter){
-    return !!stringParameter && _.isString(stringParameter) && stringParameter !== '';
+  if(expected === 'boolean'){
+    return _.isBoolean(parameter);
+  } else if(expected === 'number'){
+    return _.isNumber(parameter);
+  } else if(expected === 'string'){
+    return _.isString(parameter);
   }
+
+  return false;
 };
 
 module.exports = function(requestParameters, expectedParameters){
@@ -56,7 +46,7 @@ module.exports = function(requestParameters, expectedParameters){
       
       var expectedType = expectedParameters[requestParameterName].type;
 
-      if(!validate.parameter(requestParameter, expectedType)){
+      if(!validateParameter(requestParameter, expectedType)){
         if(!result.errors.types){
           result.errors.types = {};
           result.isValid = false;

--- a/test/unit/registry-domain-validator.js
+++ b/test/unit/registry-domain-validator.js
@@ -370,15 +370,12 @@ describe('registry : domain : validator', function(){
           expect(validateResult.errors.message).to.equal('Parameters are not correctly formatted: name');
         });
 
-        it('should not be valid when parameter is empty', function(){
+        it('should be valid when parameter is an empty string', function(){
           var requestParameters = { name: '' };
 
           var validateResult = validate(requestParameters, componentParameters);
 
-          expect(validateResult.isValid).to.be.false;
-          expect(validateResult.errors).not.to.be.empty;
-          expect(validateResult.errors.types['name']).to.equal('wrong type');
-          expect(validateResult.errors.message).to.equal('Parameters are not correctly formatted: name');
+          expect(validateResult.isValid).to.be.true;
         });
 
         describe('when non mandatory number provided', function(){


### PR DESCRIPTION
This fixes the problem for both optional and mandatory string parameters for when an empty string is provided both via a GET or a POST api request.

Specifically, currently, when a `a` parameter is an optional string, `...?c=d` is valid, `...?a=&c=d` is not. It should be instead.

Same when mandatory: `...?c=d` errors and still should, but `...?a=&c=4` errors too but it should be valid instead.