### PR TITLE
[WIP ] Recursively look for oc.json, starting from componentsDir

### DIFF
--- a/cli/facade/dev.js
+++ b/cli/facade/dev.js
@@ -109,7 +109,7 @@ module.exports = function(dependencies){
     };
 
     var registerPlugins = function(registry){
-      var mockedPlugins = getMockedPlugins(logger);
+      var mockedPlugins = getMockedPlugins(logger, componentsDir);
 
       mockedPlugins.forEach(function(p){
         registry.register(p);


### PR DESCRIPTION
This PR is in relation to this issue: https://github.com/opentable/oc/issues/219

@matteofigus I haven't had luck trying to get the test `cli : domain : get-mocked-plugins > when setting up mocked plugins > when oc.json is missing` to run successfully, I don't the best way to look for the rootDir in this line `rootDir = fs.realpathSync('.') + '/oc.json';` which also works for testing purposes.