### PR TITLE
Upgrade async

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "accept-language-parser": "1.0.2",
-    "async": "0.9.0",
+    "async": "1.5.2",
     "aws-sdk": "2.1.43",
     "clean-css": "3.4.9",
     "colors": "1.0.3",


### PR DESCRIPTION
New versions of async should have good improvements in terms of performance according to the changelog. This may be beneficial especially for heavy load when using the POST route (but no evidence of that yet).

/cc @antwhite 

PS 
This PR has some fixes on some tests as the old version of async (used in a test) used to iterate through elements synchronously so that "sync" testing was kind of possible when mocking all the async stuff. This PR includes some reworking on those tests in order to fully work asynchronously.