### PR TITLE
oc-client publish fix

### DIFF
--- a/src/registry/app-start.js
+++ b/src/registry/app-start.js
@@ -5,7 +5,7 @@ var format = require('stringformat');
 var path = require('path');
 var _ = require('underscore');
 
-var packageInfo = require('../../package.json');
+var packageInfo = require('../components/oc-client/_package/package');
 
 module.exports = function(repository, options, callback){
 
@@ -29,9 +29,12 @@ module.exports = function(repository, options, callback){
 
       logger.log(colors.yellow('Component not found. Publishing it...'));
 
-      var componentPath = path.resolve(__dirname, '../components/oc-client/_package');
+      var pkgInfo = {
+        outputFolder: path.resolve(__dirname, '../components/oc-client/_package'),
+        packageJson: packageInfo
+      };
       
-      repository.publishComponent(componentPath, 'oc-client', packageInfo.version, function(err, res){
+      repository.publishComponent(pkgInfo, 'oc-client', packageInfo.version, function(err, res){
         if(!err){
           logger.log(colors.green('Component published.'));
         } else {

--- a/test/unit/registry-app-start.js
+++ b/test/unit/registry-app-start.js
@@ -6,7 +6,7 @@ var sinon = require('sinon');
 
 var getAppStart = function(mockedRepository, options, callback){
   var appStart = injectr('../../src/registry/app-start.js', {
-        '../../package.json': { version: '1.2.3' }
+        '../components/oc-client/_package/package': { version: '1.2.3' }
       }, { console: { log: sinon.stub() }, __dirname: '.'});
       
   return appStart(mockedRepository, options, callback);


### PR DESCRIPTION
#257 changed the API for the publishComponent method. Unfortunately we forgot to update usage in the registry app-start, where the registry, when running, double-checks that the oc-client component exists in the library for the same registry version - and in case, publishes it.

This is the fix for it.