### PR TITLE
Publish fix

### DIFF
--- a/src/registry/domain/extract-package.js
+++ b/src/registry/domain/extract-package.js
@@ -19,7 +19,7 @@ module.exports = function(files, callback){
 
     if(err){ return callback(err); }
 
-    getPackageJsonFromTempDir(packageUntarOutput, function(err, packageJson){
+    getPackageJsonFromTempDir(packageOutput, function(err, packageJson){
       callback(err, {
         outputFolder: packageOutput,
         packageJson: packageJson


### PR DESCRIPTION
After #257 we made some refactoring and introduced this bug. 

Basically we look for the package.json in the wrong folder, in fact the registry api responds 
```json
{"error":"package is not valid","details":{"errno":34,"code":"ENOENT","path":"/(...)/temp/package-1467738584507/package.json"}}
```

Can you review @lukasz-lysik ?