### PR TITLE
Respect dependency versions for components

### DIFF
--- a/src/cli/domain/get-components-deps.js
+++ b/src/cli/domain/get-components-deps.js
@@ -10,7 +10,7 @@ module.exports = function(components){
     var pkg = fs.readJsonSync(path.join(c, 'package.json'));
     _.forEach(_.keys(pkg.dependencies), function(d){
       if(!_.contains(deps, d)){
-        deps.push(d);
+        deps.push(d + '@' + pkg.dependencies[d]);
       }
     });
   });

--- a/src/cli/domain/get-missing-deps.js
+++ b/src/cli/domain/get-missing-deps.js
@@ -8,7 +8,12 @@ module.exports = function(dependencies, components){
   var missing = [];
 
   _.forEach(dependencies, function(npmModule){
-    var pathToModule = path.resolve('node_modules/', npmModule);
+    var index = npmModule.indexOf('@'),
+        moduleName = npmModule;
+    if (index > 0) {
+      moduleName = npmModule.substr(0, index);
+    }
+    var pathToModule = path.resolve('node_modules/', moduleName);
 
     try {
       if(!!require.cache[pathToModule]){

--- a/src/registry/domain/dependencies-resolver.js
+++ b/src/registry/domain/dependencies-resolver.js
@@ -14,8 +14,13 @@ module.exports = function(options){
   logger.log(strings.messages.registry.RESOLVING_DEPENDENCIES.yellow);
 
   _.forEach(options.dependencies, function(dependency){
+    var dependencyName = dependency,
+        ix = dependency.indexOf('@');
+    if (ix > 0) {
+      dependencyName = dependency.substr(0, ix);
+    }
     var dependenciesBasePath = path.resolve('.', 'node_modules'),
-        dependencyPath = path.resolve(dependenciesBasePath, dependency),
+        dependencyPath = path.resolve(dependenciesBasePath, dependencyName),
         packagePath = path.resolve(dependencyPath, 'package.json');
 
     if(!fs.existsSync(packagePath)){
@@ -24,7 +29,7 @@ module.exports = function(options){
     } else {
       try {
         depObj[dependency] = require(dependencyPath);
-        logger.log('├── '.green + dependency + '@' + fs.readJsonSync(packagePath).version);
+        logger.log('├── '.green + dependencyName + '@' + fs.readJsonSync(packagePath).version);
       } catch(e){
         logger.log((dependency + ' => ').yellow + strings.errors.registry.GENERIC_ERROR.red);
         throw e;


### PR DESCRIPTION
Dependencies of components are always installed at the latest version even though a particular version might have been specified in their `package.json`.

This patch pulls in the version information from the `package.json` and forwards it to the `npm` so that the appropriate package version is installed.

Caveat: this patch needs to be made more generic so that all the formats supported by npm install are handled properly. I'm putting it up to start the discussion on the necessity of this work.