### PR TITLE
npm install and dep resolvement needs to happen in the same dir

### DIFF
--- a/src/cli/domain/get-components-deps.js
+++ b/src/cli/domain/get-components-deps.js
@@ -7,10 +7,17 @@ var _ =  require('underscore');
 module.exports = function(components){
   var deps = [];
   _.forEach(components, function(c){
+
     var pkg = fs.readJsonSync(path.join(c, 'package.json'));
+
     _.forEach(_.keys(pkg.dependencies), function(d){
-      if(!_.contains(deps, d)){
-        deps.push(d + '@' + pkg.dependencies[d]);
+
+      var version = pkg.dependencies[d],
+          hasVersion = !_.isEmpty(version),
+          depToInstall = hasVersion ? (d + '@' + version) : d;
+
+      if(!_.contains(deps, depToInstall)){
+        deps.push(depToInstall);
       }
     });
   });

--- a/src/cli/domain/get-components-deps.js
+++ b/src/cli/domain/get-components-deps.js
@@ -5,7 +5,9 @@ var path = require('path');
 var _ =  require('underscore');
 
 module.exports = function(components){
-  var deps = [];
+
+  var deps = { modules: [], withVersions: [] };
+
   _.forEach(components, function(c){
 
     var pkg = fs.readJsonSync(path.join(c, 'package.json'));
@@ -16,8 +18,12 @@ module.exports = function(components){
           hasVersion = !_.isEmpty(version),
           depToInstall = hasVersion ? (d + '@' + version) : d;
 
-      if(!_.contains(deps, depToInstall)){
-        deps.push(depToInstall);
+      if(!_.contains(deps.withVersions, depToInstall)){
+        deps.withVersions.push(depToInstall);
+      }
+
+      if(!_.contains(deps.modules, d)){
+        deps.modules.push(d);
       }
     });
   });

--- a/src/cli/domain/get-missing-deps.js
+++ b/src/cli/domain/get-missing-deps.js
@@ -8,14 +8,13 @@ module.exports = function(dependencies, components){
   var missing = [];
 
   _.forEach(dependencies, function(npmModule){
-
+ 
     var index = npmModule.indexOf('@'),
         moduleName = npmModule;
-
+    
     if (index > 0) {
       moduleName = npmModule.substr(0, index);
     }
-
     var pathToModule = path.resolve('node_modules/', moduleName);
     
     try {

--- a/src/cli/domain/get-missing-deps.js
+++ b/src/cli/domain/get-missing-deps.js
@@ -8,13 +8,16 @@ module.exports = function(dependencies, components){
   var missing = [];
 
   _.forEach(dependencies, function(npmModule){
+
     var index = npmModule.indexOf('@'),
         moduleName = npmModule;
+
     if (index > 0) {
       moduleName = npmModule.substr(0, index);
     }
-    var pathToModule = path.resolve('node_modules/', moduleName);
 
+    var pathToModule = path.resolve('node_modules/', moduleName);
+    
     try {
       if(!!require.cache[pathToModule]){
         delete require.cache[pathToModule];

--- a/src/cli/domain/npm-installer.js
+++ b/src/cli/domain/npm-installer.js
@@ -3,9 +3,9 @@
 var npm = require('npm');
 var path = require('path');
 
-module.exports = function(dependencies, baseDir, cb){
+module.exports = function(dependencies, cb){
   npm.load({}, function(npmEr){
     if(!!npmEr){ return cb(npmEr); }
-    npm.commands.install(path.resolve(baseDir), dependencies, cb);
+    npm.commands.install(path.resolve('.'), dependencies, cb);
   });
 };

--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -95,11 +95,11 @@ module.exports = function(dependencies){
       log.warn(strings.messages.cli.CHECKING_DEPENDENCIES, true);
 
       var dependencies = getComponentsDependencies(components),
-          missing = getMissingDeps(dependencies, components);
+          missing = getMissingDeps(dependencies.withVersions, components);
 
       if(_.isEmpty(missing)){
         log.ok('OK');
-        return cb(dependencies);
+        return cb(dependencies.modules);
       }
 
       log.err('FAIL');

--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -39,7 +39,7 @@ module.exports = function(dependencies){
       if(_.isEmpty(missing)){ return cb(); }
 
       log.warn(format(strings.messages.cli.INSTALLING_DEPS, missing.join(', ')));
-      npmInstaller(missing, componentsDir, function(err, result){
+      npmInstaller(missing, function(err, result){
         if(!!err){
           log.err(err.toString());
           throw err;


### PR DESCRIPTION
This PR fixes two issues:
* When working on #280 we introduced the possibility to npm install dependency@version instead of just the dependency on the latest version. The bug was that multiple components using the same dep where installed multiple times. In addition, resolving the dependency when running the component from registry resulted in a dependency bug because the dependency wasn't registered correctly. This should fix.
* The second is the fix for #284 - npm install succeeds but then goes to an infinite loop. This is actually not related to #280 and happens when doing `oc dev componentsFolder`. Basically, until now npm install was installing inside components folder, and dependency were resolved on the folder the `oc dev` was running. So, `oc dev .` was always working (so, when launching the dev inside the components folder) but `oc dev componentsFolder` wasn't. From now, with this fix, it is decided that npm dependencies are installed in a `node_modules` folder relative to the `oc dev` and that's where they are resolved. This should make the dev watcher able to run from both locations.

The easiest way to test this stuff is to use a folder of components using dependency and manually run the acceptance tests from various locations. We can also add extra unit testing but I am not too concerned as this is mostly a CLI minor feature and shouldn't have impact on a registry.

@lobut let's have a look at this together tomorrow so that we can do some manual testing together and then merge ;)