### PR TITLE
Removing spaces from decodedUrl params before passing for [GT-1372]

### DIFF
--- a/src/registry/domain/url-builder.js
+++ b/src/registry/domain/url-builder.js
@@ -42,7 +42,7 @@ var build = {
       qs += '?';
 
       _.forEach(parameters, function(parameter, key){
-        qs += key + '=' + encodeURIComponent(parameter) + '&';
+        qs += key.replace(/\s/g, '') + '=' + encodeURIComponent(parameter) + '&';
       });
 
       if(_.keys(parameters).length > 0){


### PR DESCRIPTION
https://opentable.atlassian.net/browse/GT-1372

Let me know, if there's any changes you want. i.e. maybe more sanitization or such