### PR TITLE
Upgrade async + wrap s3 calls to timeout

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,9 +8,9 @@
       "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.1.2.tgz"
     },
     "async": {
-      "version": "1.5.2",
-      "from": "async@1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+      "version": "2.1.2",
+      "from": "async@2.1.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz"
     },
     "aws-sdk": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "accept-language-parser": "1.1.2",
-    "async": "1.5.2",
+    "async": "2.1.2",
     "aws-sdk": "2.4.2",
     "clean-css": "3.4.18",
     "colors": "1.1.2",

--- a/src/registry/domain/s3.js
+++ b/src/registry/domain/s3.js
@@ -34,7 +34,7 @@ module.exports = function(conf){
     listSubDirectories: function(dir, callback){
 
       var normalisedPath = dir.lastIndexOf('/') === (dir.length - 1) && dir.length > 0 ? dir : dir + '/',
-          listObjects = async.timeout(client.listObjects, timeout);
+          listObjects = async.timeout(client.listObjects.bind(client), timeout);
 
       listObjects({
         Bucket: bucket,
@@ -64,7 +64,7 @@ module.exports = function(conf){
         force = false;
       }
 
-      var getObject = async.timeout(client.getObject, timeout);
+      var getObject = async.timeout(client.getObject.bind(client), timeout);
 
       var getFromAws = function(callback){
         getObject({
@@ -135,7 +135,7 @@ module.exports = function(conf){
     putFileContent: function(fileContent, fileName, isPrivate, callback){
 
       var fileInfo = getFileInfo(fileName),
-          putObject = async.timeout(client.putObject, timeout),
+          putObject = async.timeout(client.putObject.bind(client), timeout),
           obj = {
             Bucket: bucket,
             Key: fileName,


### PR DESCRIPTION
As discussed with @jwhayes it seems like there are some edge cases when s3 could not respond with the callback and break the polling mechanism. This shouldn't hurt as it just adds a bit of a extra safety around the s3 calls with a timeout wrapper.

All tests still green and did some manual testing with a real registry instance.