### PR TITLE
Revert async upgrade + timeout wrapping

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,9 +8,9 @@
       "resolved": "https://registry.npmjs.org/accept-language-parser/-/accept-language-parser-1.1.2.tgz"
     },
     "async": {
-      "version": "2.1.2",
-      "from": "async@2.1.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.2.tgz"
+      "version": "1.5.2",
+      "from": "async@1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
     },
     "aws-sdk": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "accept-language-parser": "1.1.2",
-    "async": "2.1.2",
+    "async": "1.5.2",
     "aws-sdk": "2.4.2",
     "clean-css": "3.4.18",
     "colors": "1.1.2",

--- a/src/registry/domain/s3.js
+++ b/src/registry/domain/s3.js
@@ -14,13 +14,11 @@ var strings = require('../../resources');
 
 module.exports = function(conf){
 
-  var timeout = conf.s3.timeout || 10000;
-
   AWS.config.update({
     accessKeyId: conf.s3.key,
     secretAccessKey: conf.s3.secret,
     region: conf.s3.region,
-    httpOptions: { timeout: timeout }
+    httpOptions: { timeout: conf.s3.timeout || 10000 }
   });
 
   var client = new AWS.S3(),
@@ -33,10 +31,9 @@ module.exports = function(conf){
   return {
     listSubDirectories: function(dir, callback){
 
-      var normalisedPath = dir.lastIndexOf('/') === (dir.length - 1) && dir.length > 0 ? dir : dir + '/',
-          listObjects = async.timeout(client.listObjects.bind(client), timeout);
+      var normalisedPath = dir.lastIndexOf('/') === (dir.length - 1) && dir.length > 0 ? dir : dir + '/';
 
-      listObjects({
+      client.listObjects({
         Bucket: bucket,
         Prefix: normalisedPath,
         Delimiter: '/'
@@ -64,10 +61,8 @@ module.exports = function(conf){
         force = false;
       }
 
-      var getObject = async.timeout(client.getObject.bind(client), timeout);
-
       var getFromAws = function(callback){
-        getObject({
+        client.getObject({
           Bucket: bucket,
           Key: filePath
         }, function(err, data){
@@ -135,7 +130,6 @@ module.exports = function(conf){
     putFileContent: function(fileContent, fileName, isPrivate, callback){
 
       var fileInfo = getFileInfo(fileName),
-          putObject = async.timeout(client.putObject.bind(client), timeout),
           obj = {
             Bucket: bucket,
             Key: fileName,
@@ -153,7 +147,7 @@ module.exports = function(conf){
         obj.ContentEncoding = 'gzip';
       }
 
-      putObject(obj, callback);
+      client.putObject(obj, callback);
     }
   };
 };


### PR DESCRIPTION
This reverts #310 as new version of async seems not very performant compared to previous and wrapping calls seems not to be useful.