### PR TITLE
Migrate tar.gz to targz

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3076,26 +3076,16 @@
       "from": "stringformat@0.0.5",
       "resolved": "https://registry.npmjs.org/stringformat/-/stringformat-0.0.5.tgz"
     },
-    "tar.gz": {
-      "version": "0.1.1",
-      "from": "tar.gz@0.1.1",
-      "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-0.1.1.tgz",
+    "targz": {
+      "version": "1.0.1",
+      "from": "targz@1.0.1",
+      "resolved": "https://registry.npmjs.org/targz/-/targz-1.0.1.tgz",
       "dependencies": {
-        "fstream": {
-          "version": "0.1.31",
-          "from": "fstream@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+        "tar-fs": {
+          "version": "1.14.0",
+          "from": "tar-fs@>=1.8.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.14.0.tgz",
           "dependencies": {
-            "graceful-fs": {
-              "version": "3.0.8",
-              "from": "graceful-fs@>=3.0.2 <3.1.0",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.8.tgz"
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <2.1.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            },
             "mkdirp": {
               "version": "0.5.1",
               "from": "mkdirp@>=0.5.0 <0.6.0",
@@ -3108,60 +3098,19 @@
                 }
               }
             },
-            "rimraf": {
-              "version": "2.5.3",
-              "from": "rimraf@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
+            "pump": {
+              "version": "1.0.1",
+              "from": "pump@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.1.tgz",
               "dependencies": {
-                "glob": {
-                  "version": "7.0.5",
-                  "from": "glob@>=7.0.5 <8.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "from": "end-of-stream@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                   "dependencies": {
-                    "fs.realpath": {
-                      "version": "1.0.0",
-                      "from": "fs.realpath@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-                    },
-                    "inflight": {
-                      "version": "1.0.5",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.2",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "minimatch": {
-                      "version": "3.0.2",
-                      "from": "minimatch@>=3.0.2 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.5",
-                          "from": "brace-expansion@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "0.4.2",
-                              "from": "balanced-match@>=0.4.1 <0.5.0",
-                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
                     "once": {
                       "version": "1.3.3",
-                      "from": "once@>=1.3.0 <2.0.0",
+                      "from": "once@>=1.3.0 <1.4.0",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                       "dependencies": {
                         "wrappy": {
@@ -3170,140 +3119,139 @@
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                         }
                       }
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "from": "once@>=1.3.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                     }
                   }
                 }
               }
-            }
-          }
-        },
-        "tar": {
-          "version": "2.2.1",
-          "from": "tar@latest",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "dependencies": {
-            "block-stream": {
-              "version": "0.0.9",
-              "from": "block-stream@*",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
             },
-            "fstream": {
-              "version": "1.0.10",
-              "from": "fstream@>=1.0.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+            "tar-stream": {
+              "version": "1.5.2",
+              "from": "tar-stream@>=1.1.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.2.tgz",
               "dependencies": {
-                "graceful-fs": {
-                  "version": "4.1.4",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.4.tgz"
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.0 >=0.0.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                "bl": {
+                  "version": "1.1.2",
+                  "from": "bl@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-1.1.2.tgz",
                   "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.5.3",
-                  "from": "rimraf@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.3.tgz",
-                  "dependencies": {
-                    "glob": {
-                      "version": "7.0.5",
-                      "from": "glob@>=7.0.5 <8.0.0",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.5.tgz",
+                    "readable-stream": {
+                      "version": "2.0.6",
+                      "from": "readable-stream@>=2.0.5 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
                       "dependencies": {
-                        "fs.realpath": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                        },
+                        "isarray": {
                           "version": "1.0.0",
-                          "from": "fs.realpath@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                         },
-                        "inflight": {
-                          "version": "1.0.5",
-                          "from": "inflight@>=1.0.4 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                            }
-                          }
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                         },
-                        "minimatch": {
-                          "version": "3.0.2",
-                          "from": "minimatch@>=3.0.2 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
-                          "dependencies": {
-                            "brace-expansion": {
-                              "version": "1.1.5",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
-                              "dependencies": {
-                                "balanced-match": {
-                                  "version": "0.4.2",
-                                  "from": "balanced-match@>=0.4.1 <0.5.0",
-                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                                },
-                                "concat-map": {
-                                  "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
-                        "once": {
-                          "version": "1.3.3",
-                          "from": "once@>=1.3.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "path-is-absolute": {
-                          "version": "1.0.0",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                         }
                       }
                     }
                   }
+                },
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "from": "end-of-stream@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.1.5",
+                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+                  "dependencies": {
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "from": "buffer-shims@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
                 }
               }
-            },
-            "inherits": {
-              "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-            }
-          }
-        },
-        "commander": {
-          "version": "1.1.1",
-          "from": "commander@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
-          "dependencies": {
-            "keypress": {
-              "version": "0.1.0",
-              "from": "keypress@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "read": "1.0.7",
     "semver": "5.1.1",
     "stringformat": "0.0.5",
-    "tar.gz": "0.1.1",
+    "targz": "1.0.1",
     "uglify-js": "2.6.4",
     "underscore": "1.8.3",
     "watch": "0.19.1"

--- a/src/cli/domain/local.js
+++ b/src/cli/domain/local.js
@@ -2,7 +2,7 @@
 
 var fs = require('fs-extra');
 var path = require('path');
-var Targz = require('tar.gz');
+var targz = require('targz');
 var _ = require('underscore');
 
 var getComponentsByDir = require('./get-components-by-dir');
@@ -13,14 +13,23 @@ var validator = require('../../registry/domain/validators');
 
 module.exports = function(dependencies){
   var logger = dependencies.logger;
-  var targz = new Targz();
 
   return _.extend(this, {
     cleanup: function(compressedPackagePath, callback){
       return fs.unlink(compressedPackagePath, callback);
     },
     compress: function(input, output, callback){
-      return targz.compress(input, output, callback);
+      return targz.compress({
+        src: input,
+        dest: output,
+        tar: {
+          map: function(file){
+            return _.extend(file, {
+              name: '_package/' + file.name
+            });
+          }
+        }
+      }, callback);
     },
     getComponentsByDir: getComponentsByDir(dependencies),
     getLocalNpmModules: getLocalNpmModules(),

--- a/src/registry/domain/extract-package.js
+++ b/src/registry/domain/extract-package.js
@@ -1,12 +1,10 @@
 'use strict';
 
 var path = require('path');
-var Targz = require('tar.gz');
+var targz = require('targz');
 var _ = require('underscore');
 
 var getPackageJsonFromTempDir = require('./get-package-json-from-temp-dir');
-
-var targz = new Targz();
 
 module.exports = function(files, callback){
 
@@ -15,7 +13,10 @@ module.exports = function(files, callback){
       packageUntarOutput = path.resolve(packageFile.path, '..', packageFile.name.replace('.tar.gz', '')),
       packageOutput = path.resolve(packageUntarOutput, '_package');
 
-  targz.extract(packagePath, packageUntarOutput, function(err){
+  targz.extract({
+    src: packagePath,
+    dest: packageUntarOutput
+  }, function(err){
 
     if(err){ return callback(err); }
 

--- a/test/integration/targz.js
+++ b/test/integration/targz.js
@@ -3,22 +3,28 @@
 var expect = require('chai').expect;
 var fs = require('fs-extra');
 var path = require('path');
-var Targz = require('tar.gz');
+var targz = require('targz');
+var _ = require('underscore');
 
-describe('The Targz dependency', function(){
-  var targz;
+describe('The targz dependency', function(){
 
-  beforeEach(function(){
-    targz = new Targz();
-  });
-
-  describe('when compressing a folder', function(){
+  describe('when compressing a folder with targz', function(){
     
     var file = path.resolve(__dirname, '../fixtures/test.tar.gz');
 
     beforeEach(function(done){
-      var from = path.resolve(__dirname, '../fixtures/components/hello-world');
-      targz.compress(from, file, done);
+     var from = path.resolve(__dirname, '../fixtures/components/hello-world');
+      targz.compress({
+        src: from,
+        dest: file,
+        tar: {
+          map: function(fileName) {
+            return _.extend(fileName, {
+              name: 'hello-world/' + fileName.name
+            });
+          }
+        }
+      }, done);
     });
 
     it('should create the file', function(){
@@ -31,7 +37,10 @@ describe('The Targz dependency', function(){
           to = path.resolve(__dirname, '../fixtures/targz-test'); 
 
       beforeEach(function(done){ 
-        targz.extract(file, to, function(err){
+        targz.decompress({
+          src: file,
+          dest: to
+        }, function(err){
           error = err;
           done();
         });

--- a/test/integration/targz.js
+++ b/test/integration/targz.js
@@ -13,7 +13,7 @@ describe('The targz dependency', function(){
     var file = path.resolve(__dirname, '../fixtures/test.tar.gz');
 
     beforeEach(function(done){
-     var from = path.resolve(__dirname, '../fixtures/components/hello-world');
+      var from = path.resolve(__dirname, '../fixtures/components/hello-world');
       targz.compress({
         src: from,
         dest: file,


### PR DESCRIPTION
This solves #277 

Specifically, tar.gz
- has vulnerability issues (patched in the npm-shrinkwrap but still not great)
- doesn't work with node>6
- is not maintained anymore and latest version has known bugs

targz is minimal, works great, and keeps the tests green.

Note for reviewer: apart from the little difference in the interface, the old module used by default to compress a folder by including the folder too, while the new one includes just the files. If you look at the implementation, the `tar.map` is for solving that exact problem and keeping the format identical (so that cli and api keep talking with the same format).

Note that there is an integration test too to verify compressing/decompressing actually work with a real file.
