### PR TITLE
Client dynamic hrefs

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -90,6 +90,9 @@ Options:
 |`headers`|`object`|no|An object containing all the headers that must be forwarded to the component|
 |`ie8`|`boolean`|no|Default false, if true puts in place the necessary polyfills to make all the stuff work with ie8|
 |`parameters`|`object`|no|An object containing the parameters for component's request|
+|`registries`|`object`|no|The registries' endpoints (overrides the parameters defined during instantiation)|
+|`registries.serverRendering`|`string`|no|The baseUrl for server-side rendering requests (overrides the parameter defined during instantiation)|
+|`registries.clientRendering`|`string`|no|The baseUrl for client-side rendering requests (overrides the parameter defined during instantiation)|
 |`render`|`string`|no|Default `server`. When `server`, it will return html. When `client` will produce the html to put in the page for post-poning the rendering to the browser|
 |`timeout`|`number` (seconds)|no|Default 5. When request times-out, the callback will be fired with a timeout error and a client-side rendering response (unless `disableFailoverRendering` is set to `true`)|
 
@@ -132,9 +135,13 @@ Options:
 |---------|----|---------|-----------|
 |`container`|`boolean`|no|Default true, when false, renders a component without its <oc-component> container|
 |`disableFailoverRendering`|`boolean`|no|Disables the automatic failover rendering in case the registry times-out (in case configuration.registries.clientRendering contains a valid value.) Default false|
+|`forwardAcceptLanguageToClient`|`boolean`|no|When not specified in config, defaults to false. When true, when doing client-side requests (normal or failover) appends a custom parameter to the browser's component hrefs so that the framework will ignore the browser's Accept-Language in favour of the query-string value|
 |`headers`|`object`|no|An object containing all the headers that must be forwarded to the component|
 |`ie8`|`boolean`|no|Default false, if true puts in place the necessary polyfills to make all the stuff work with ie8|
 |`parameters`|`object`|no|Global parameters for all components to retrieve. When component has its own parameters, globals will be overwritten|
+|`registries`|`object`|no|The registries' endpoints (overrides the parameters defined during instantiation)|
+|`registries.serverRendering`|`string`|no|The baseUrl for server-side rendering requests (overrides the parameter defined during instantiation)|
+|`registries.clientRendering`|`string`|no|The baseUrl for client-side rendering requests (overrides the parameter defined during instantiation)|
 |`render`|`string`|no|Default `server`. When `server`, it will return html. When `client` will produce the html to put in the page for post-poning the rendering to the browser|
 |`timeout`|`number` (seconds)|no|Default 5. When request times-out, the callback will be fired with a timeout error and a client-side rendering response (unless `disableFailoverRendering` is set to `true`)|
 

--- a/client/src/get-components-data.js
+++ b/client/src/get-components-data.js
@@ -11,7 +11,14 @@ module.exports = function(config){
   return function(toDo, options, cb){
 
     var serverRenderingFail = settings.serverSideRenderingFail,
-        serverRendering = { components: [], positions: [] };
+        serverRendering = { components: [], positions: [] },
+        serverRenderingEndpoint;
+
+    if(!!options && !!options.registries && !!options.registries.serverRendering){
+      serverRenderingEndpoint = options.registries.serverRendering;
+    } else if(!!config && !!config.registries){
+      serverRenderingEndpoint = config.registries.serverRendering;
+    }
 
     _.each(toDo, function(action){
       if(action.render === 'server'){
@@ -22,7 +29,7 @@ module.exports = function(config){
 
     if(_.isEmpty(serverRendering.components)){
       return cb();
-    } else if(!config.registries.serverRendering){
+    } else if(!serverRenderingEndpoint){
       _.each(toDo, function(action){
         action.result.error = serverRenderingFail;
         if(!!options.disableFailoverRendering){
@@ -38,7 +45,7 @@ module.exports = function(config){
     }
 
     var requestDetails = {
-      url: config.registries.serverRendering,
+      url: serverRenderingEndpoint,
       method: 'post',
       headers: options.headers,
       timeout: options.timeout,

--- a/client/src/href-builder.js
+++ b/client/src/href-builder.js
@@ -7,7 +7,14 @@ module.exports = function(config){
 
   return {
     client: function(component, options){
-      if(!config.registries.clientRendering){
+
+      var clientRenderingEndpoint;
+
+      if(!!options && !!options.registries && !!options.registries.clientRendering){
+        clientRenderingEndpoint = options.registries.clientRendering;
+      } else if(!!config && !!config.registries && !!config.registries.clientRendering){
+        clientRenderingEndpoint = config.registries.clientRendering;
+      } else {
         return null;
       }
 
@@ -24,7 +31,7 @@ module.exports = function(config){
       }
 
       var versionSegment = !!component.version ? ('/' + component.version) : '',
-          registryUrl = config.registries.clientRendering,
+          registryUrl = clientRenderingEndpoint,
           registrySegment = registryUrl.slice(-1) === '/' ? registryUrl : (registryUrl + '/'),
           qs = !!component.parameters ? ('/?' + querystring.stringify(component.parameters)) : '';
 

--- a/test/acceptance/client.js
+++ b/test/acceptance/client.js
@@ -308,6 +308,52 @@ describe('The node.js OC client', function(){
       });
     });
 
+    describe('when server-side rendering an existing component overriding registry urls', function(){
+
+      before(function(done){
+        var options = {
+          container: true,
+          registries: {
+            clientRendering: 'http://localhost:3030',
+            serverRendering: 'http://localhost:3030'
+          }
+        };
+
+        clientOfflineRegistry.renderComponent('hello-world', options, function(err, html){
+          $component = cheerio.load(html)('oc-component');
+          done();
+        });
+      });
+
+      it('should use the overwritten serverRendering url', function(){
+        expect($component.attr('href')).to.equal('http://localhost:3030/hello-world/~1.0.0');
+        expect($component.data('rendered')).to.equal(true);
+      });
+    });
+
+    describe('when client-side rendering an existing component overriding registry urls', function(){
+
+      before(function(done){
+        var options = {
+          container: true,
+          registries: {
+            clientRendering: 'http://localhost:3030',
+            serverRendering: 'http://localhost:3030'
+          },
+          render: 'client'
+        };
+
+        clientOfflineRegistry.renderComponent('hello-world', options, function(err, html){
+          $component = cheerio.load(html)('oc-component');
+          done();
+        });
+      });
+
+      it('should use the overwritten clientRendering url', function(){
+        expect($component.attr('href')).to.equal('http://localhost:3030/hello-world/~1.0.0');
+      });
+    });
+
     describe('when client-side rendering an existing component', function(){
 
       before(function(done){


### PR DESCRIPTION
Allows to override registry baseUrls on each `renderingComponent` or `renderingComponents` call.