### PR TITLE
Add optional cache headers for components (#325)

### DIFF
--- a/src/registry/routes/component.js
+++ b/src/registry/routes/component.js
@@ -19,6 +19,10 @@ module.exports = function(conf, repository){
         res.errorDetails = result.response.error;
       }
 
+      if (result.response.headers) {
+        res.set(result.response.headers);
+      }
+
       return res.json(result.status, result.response);
     });
   };

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -26,7 +26,8 @@ module.exports = function(conf, repository){
       cache = new Cache({
         verbose: !!conf.verbosity,
         refreshInterval: conf.refreshInterval
-      });
+      }),
+      responseHeaders;
 
   var renderer = function(options, cb){
 
@@ -188,6 +189,10 @@ module.exports = function(conf, repository){
                 });
               }
 
+              if (responseHeaders) {
+                response.headers = responseHeaders;
+              }
+
               callback({
                 status: 200, 
                 response: _.extend(response, { html: html })
@@ -225,7 +230,11 @@ module.exports = function(conf, repository){
               renderComponent: nestedRenderer.renderComponent,
               renderComponents: nestedRenderer.renderComponents,
               requestHeaders: options.headers,
-              staticPath: repository.getStaticFilePath(component.name, component.version, '').replace('https:', '')
+              staticPath: repository.getStaticFilePath(component.name, component.version, '').replace('https:', ''),
+              setHeader: function(header, value) {
+                responseHeaders = responseHeaders || {};
+                responseHeaders[header] = value;
+              }
             };
 
         var setCallbackTimeout = function(){

--- a/test/fixtures/mocked-components/index.js
+++ b/test/fixtures/mocked-components/index.js
@@ -7,5 +7,6 @@ module.exports = {
   'npm-component': require('./npm'),
   'plugin-component': require('./plugin'),
   'timeout-component': require('./timeout'),
-  'undefined-component': require('./undefined')
+  'undefined-component': require('./undefined'),
+  'response-headers-component': require('./response-headers')
 };

--- a/test/fixtures/mocked-components/response-headers.js
+++ b/test/fixtures/mocked-components/response-headers.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  package: {
+    name: 'response-headers-component',
+    version: '1.0.0',
+    oc: {
+      container: false,
+      renderInfo: false,
+      files: {
+        template: {
+          type: 'jade',
+          hashKey: '8c1fbd954f2b0d8cd5cf11c885fed4805225749f',
+          src: 'template.js'
+        },
+        dataProvider: {
+          type: 'node.js',
+          hashKey: '123456',
+          src: 'server.js'
+        }
+      }
+    }
+  },
+  data: '"use strict";module.exports.data = function(ctx, cb){ctx.setHeader("test-header","test-value"); cb(null, {done:true});};',
+  view: 'var oc=oc||{};oc.components=oc.components||{},oc.components["8c1fbd954f2b0d8cd5cf11c885fed4805225749f"]' +
+        '=function(){var o=[];return o.push("<div>hello</div>"),o.join("")};'
+};

--- a/test/unit/registry-routes-component.js
+++ b/test/unit/registry-routes-component.js
@@ -417,4 +417,53 @@ describe('registry : routes : component', function(){
       });
     });
   });
+
+  describe('when getting a component with server.js that sets custom headers', function() {
+
+    var code, response, headers;
+
+    before(function(done) {
+      initialise(mockedComponents['response-headers-component']);
+      componentRoute = new ComponentRoute({}, mockedRepository);
+
+      var resJson = function(calledCode, calledResponse) {
+        code = calledCode;
+        response = calledResponse;
+        done();
+      };
+
+      var resSet = function(calledHeaders) {
+        headers = calledHeaders;
+      };
+
+      componentRoute({
+        headers: {},
+        params: { componentName: 'response-headers-component', componentVersion: '1.X.X' }
+      }, {
+        conf: {
+          baseUrl: 'http://component.com/',
+          executionTimeout: 0.1
+        },
+        json: resJson,
+        set: resSet
+      });
+    });
+
+    it('should return 200 status code', function() {
+      expect(code).to.be.equal(200);
+    });
+
+    it('should set response headers', function() {
+      expect(response.headers).to.not.be.null;      
+      expect(response.headers['test-header']).to.equal('test-value');
+      expect(headers).to.not.be.null;      
+      expect(headers['test-header']).to.equal('test-value');
+    });
+
+    it('should return component\'s name and request version', function() {
+      expect(response.name).to.equal('response-headers-component');
+      expect(response.requestVersion).to.equal('1.X.X');
+    });
+  });
+
 });


### PR DESCRIPTION
* Added a function setHeader(name, value) to the context object that we pass to the component data function.

* Subsequently these headers (if added) will be set in the response data for the returned component JSON as well as normal HTTP response headers (component.js)

* Added a mock component (response-headers-component) and a test to cover the new functionality