### PR TITLE
(327) Fix - Custom headers of one component can appear to another.

### DIFF
--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -26,13 +26,13 @@ module.exports = function(conf, repository){
       cache = new Cache({
         verbose: !!conf.verbosity,
         refreshInterval: conf.refreshInterval
-      }),
-      responseHeaders;
+      });
 
   var renderer = function(options, cb){
 
     var nestedRenderer = new NestedRenderer(renderer, options.conf),
-        retrievingInfo = new GetComponentRetrievingInfo(options);
+        retrievingInfo = new GetComponentRetrievingInfo(options),
+        responseHeaders;
 
     var getLanguage = function(){
       var paramOverride = !!options.parameters && options.parameters['__ocAcceptLanguage'];

--- a/test/fixtures/mocked-components/another-response-headers.js
+++ b/test/fixtures/mocked-components/another-response-headers.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  package: {
+    name: 'another-response-headers-component',
+    version: '1.0.0',
+    oc: {
+      container: false,
+      renderInfo: false,
+      files: {
+        template: {
+          type: 'jade',
+          hashKey: '8c1fbd954f2b0d8cd5cf11c885fed4805225749f',
+          src: 'template.js'
+        },
+        dataProvider: {
+          type: 'node.js',
+          hashKey: '123456',
+          src: 'server.js'
+        }
+      }
+    }
+  },
+  data: '"use strict";module.exports.data = function(ctx, cb){ctx.setHeader("another-test-header","another-test-value"); cb(null, {done:true});};',
+  view: 'var oc=oc||{};oc.components=oc.components||{},oc.components["8c1fbd954f2b0d8cd5cf11c885fed4805225749f"]' +
+        '=function(){var o=[];return o.push("<div>hello</div>"),o.join("")};'
+};

--- a/test/fixtures/mocked-components/index.js
+++ b/test/fixtures/mocked-components/index.js
@@ -8,5 +8,7 @@ module.exports = {
   'plugin-component': require('./plugin'),
   'timeout-component': require('./timeout'),
   'undefined-component': require('./undefined'),
-  'response-headers-component': require('./response-headers')
+  'simple-component': require('./simple'),
+  'response-headers-component': require('./response-headers'),
+  'another-response-headers-component': require('./another-response-headers')
 };

--- a/test/fixtures/mocked-components/simple.js
+++ b/test/fixtures/mocked-components/simple.js
@@ -1,0 +1,27 @@
+'use strict';
+
+module.exports = {
+  package: {
+    name: 'simple-component',
+    version: '1.0.0',
+    oc: {
+      container: false,
+      renderInfo: false,
+      files: {
+        template: {
+          type: 'jade',
+          hashKey: '8c1fbd954f2b0d8cd5cf11c885fed4805225749f',
+          src: 'template.js'
+        },
+        dataProvider: {
+          type: 'node.js',
+          hashKey: '123457',
+          src: 'server.js'
+        }
+      }
+    }
+  },
+  data: '"use strict";module.exports.data = function(ctx, cb){cb(null, {done:true});};',
+  view: 'var oc=oc||{};oc.components=oc.components||{},oc.components["8c1fbd954f2b0d8cd5cf11c885fed4805225749f"]' +
+        '=function(){var o=[];return o.push("<div>hello</div>"),o.join("")};'
+};


### PR DESCRIPTION
The problem was introduced with #326 -
In get-component.js the declaration of responseHeaders variable happens in a more
global scope than it should be. For this reason every invocation of renderer
function sees the changes in the headers made by previously requested
components.
The fix is to just move the declaration one scope inner.

- Added a unit test to validate the fix - it tries to load two components
subsequently. The first one does provide custom headers while the second
one - don't. Then we check and expect to see there are no custom headers
in the result for the second one.