### PR TITLE
Client fixes and some tests

### DIFF
--- a/client/src/get-compiled-template.js
+++ b/client/src/get-compiled-template.js
@@ -1,8 +1,10 @@
 'use strict';
 
+var format = require('stringformat');
 var request = require('minimal-request');
 
 var executor = require('./executor');
+var settings = require('./settings');
 var TryGetCached = require('./try-get-cached');
 
 module.exports = function(cache){
@@ -16,7 +18,15 @@ module.exports = function(cache){
         url: template.src,
         timeout: timeout
       }, function(err, templateText){
-        if(!!err){ return cb(err); }
+        if(!!err){
+          return cb({
+            status: err,
+            response: {
+              error: format(settings.connectionError, template.src, templateText)
+            }
+          });
+        }
+
         cb(null, executor.template(templateText, template));
        });
     };

--- a/client/src/render-components.js
+++ b/client/src/render-components.js
@@ -54,7 +54,7 @@ module.exports = function(cache, renderTemplate){
       fetchTemplateAndRender(action.apiResponse, options, function(err, html){
         if(!!err){
           var errorDetails = format('{0} ({1})', (err.response && err.response.error), err.status);
-          action.result.error = new Error(format(settings.serverRenderingFail, errorDetails));
+          action.result.error = new Error(format(settings.serverSideRenderingFail, errorDetails));
           if(!!options.disableFailoverRendering){
             action.result.html = '';
             action.done = true;

--- a/test/unit/client-get-compiled-template.js
+++ b/test/unit/client-get-compiled-template.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var expect = require('chai').expect;
+var injectr = require('injectr');
+var sinon = require('sinon');
+
+describe('client : get-compiled-template', function(){
+
+  var getCompiledTemplate;
+
+  var initialise = function(requestStub){
+
+    var GetCompiledTemplate = injectr('../../client/src/get-compiled-template.js', {
+      'minimal-request': requestStub,
+      './try-get-cached': sinon.stub()
+    });
+
+    getCompiledTemplate = new GetCompiledTemplate();
+  };
+
+  describe('when template file request fails', function(){
+    
+    var errorExample = '<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code><Message>' +
+      'Access Denied</Message><RequestId>1234567890</RequestId><HostId>asdfghjklqwertyuiop</HostId></Error>';
+    
+    var requestStub = sinon.stub().yields(403, errorExample),
+        error;
+
+    before(function(done){
+      initialise(requestStub);
+
+      var template = {
+        key: 'hash1234567890',
+        src: 'https://cdn.com/components/1.3.5/template.js'
+      };
+
+      getCompiledTemplate(template, false, 5, function(err, result){
+        error = err;
+        done();
+      });
+    });
+
+    it('should return an error containing the details', function(){
+      expect(error).to.eql({
+        status: 403,
+        response: {
+          error: 'request https://cdn.com/components/1.3.5/template.js failed ('+ errorExample +')'
+        }
+      });
+    });
+  });
+});

--- a/test/unit/client-render-components.js
+++ b/test/unit/client-render-components.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var expect = require('chai').expect;
+var injectr = require('injectr');
+var sinon = require('sinon');
+
+describe('client : render-components', function(){
+
+  var renderComponents;
+
+  var initialise = function(getCompiledTemplateStub){
+
+    var RenderComponents = injectr('../../client/src/render-components.js', {
+      './get-compiled-template': function(){
+        return getCompiledTemplateStub;
+      }
+    });
+
+    renderComponents = new RenderComponents();
+  };
+
+  describe('when compiled template fetch fails', function(){
+    
+    var errorExample = 'request https://cdn.com/components/1.3.5/template.js failed (' +
+      '<?xml version="1.0" encoding="UTF-8"?><Error><Code>AccessDenied</Code><Message>' +
+      'Access Denied</Message><RequestId>1234567890</RequestId><HostId>asdfghjklqwertyuiop</HostId></Error>)';
+    
+    var getCompiledTemplateStub = sinon.stub().yields({
+      status: 403,
+      response: {
+        error: errorExample
+      }
+    });
+
+    var toDo;
+
+    before(function(done){
+      initialise(getCompiledTemplateStub);
+
+      toDo = [{
+        render: 'server',
+        apiResponse: {
+          some: 'properties'
+        },
+        result: {}
+      }];
+
+      renderComponents(toDo, {}, done);
+    });
+
+    it('should return an error containing the details', function(){
+      expect(toDo[0].result.error.toString()).to.eql('Error: Server-side rendering failed: ' + errorExample + ' (403)');
+    });
+
+    it('should schedule it to be rendered as client-side as failover', function(){
+      expect(toDo[0].render).to.equal('client');
+      expect(toDo[0].failover).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
There are some little issues with errors logging from the node client, specifically when template fetching fails from CDN request.

This PR is to ensure error is produced correctly.