### PR TITLE
Add endpoint for getting list of components with their versions (#324)

### DIFF
--- a/client/src/get-components-info.js
+++ b/client/src/get-components-info.js
@@ -1,0 +1,99 @@
+'use strict';
+
+var format = require('stringformat');
+var request = require('minimal-request');
+
+var settings = require('./settings');
+var sanitiser = require('./sanitiser');
+var _ = require('./utils/helpers');
+
+module.exports = function(config) {
+
+  return function(components, options, callback) {
+    if (!_.isArray(components)) {
+      components = [components];
+    }
+
+    if (_.isFunction(options)) {
+      callback = options;
+    }
+
+    options = sanitiser.sanitiseGlobalGetInfoOptions(options);
+
+    var serverRenderingEndpoint;
+    if(!!options && !!options.registries && !!options.registries.serverRendering){
+      serverRenderingEndpoint = options.registries.serverRendering;
+    } else if(!!config && !!config.registries){
+      serverRenderingEndpoint = config.registries.serverRendering;
+    }
+
+    var actions = { requestedComponents: [], responseData: [] };
+
+    _.each(components, function(component) {
+      actions.requestedComponents.push({
+        name: component.name,
+        version: component.version
+      });
+
+      actions.responseData.push({
+        componentName: component.name,
+        requestedVersion: component.version
+      });
+    });
+    
+    var requestDetails = {
+      url: serverRenderingEndpoint,
+      method: 'post',
+      headers: options.headers,
+      timeout: options.timeout,
+      json: true,
+      body: {
+        components: actions.requestedComponents
+      }
+    };
+
+    request(requestDetails, function(error, responses) {
+      if(!!error || !responses || _.isEmpty(responses)) {
+        responses = [];
+        var errorDetails = !!error ? error.toString() : settings.emptyResponse;
+        _.each(actions.requestedComponents, function(){
+          responses.push({
+            response: {
+              error: format(settings.connectionError, JSON.stringify(requestDetails), errorDetails)
+            }
+          });
+        });
+      }
+
+      var errors = [];
+      var hasErrors = false;
+
+      _.each(responses, function(response, i) {
+        var action = actions.requestedComponents[i];
+        var responseData = actions.responseData[i];
+
+        if (response.status !== 200) {
+          var errorDetails;
+          if (!response.status && response.response.error) {
+            errorDetails = response.response.error;
+          } else {
+            var errorDescription = (response.response && response.response.error);
+            if (errorDescription && response.response.details && response.response.details.originalError) {
+              errorDescription += response.response.details.originalError;
+            }
+            errorDetails = format('{0} ({1})', errorDescription || '', response.status);
+          }
+
+          responseData.error = new Error(format(settings.componentGetInfoFail, errorDetails));
+          errors.push(responseData.error);
+          hasErrors = true;
+        } else {
+          responseData.apiResponse = response.response;
+          errors.push(null);
+        }
+      });
+
+      callback(hasErrors ? errors : null, actions.responseData);
+    });
+  };
+};

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var ComponentsRenderer = require('./components-renderer');
+var GetComponentsInfo = require('./get-components-info');
+
 var sanitiser = require('./sanitiser');
 var TemplateRenderer = require('./template-renderer');
 var validator = require('./validator');
@@ -12,7 +14,8 @@ module.exports = function(conf){
   var config = sanitiser.sanitiseConfiguration(conf),
       validationResult = validator.validateConfiguration(config),
       renderTemplate = new TemplateRenderer(),
-      renderComponents = new ComponentsRenderer(config, renderTemplate);
+      renderComponents = new ComponentsRenderer(config, renderTemplate),
+      getComponentsInfo = new GetComponentsInfo(config);
 
   if(!validationResult.isValid){
     throw new Error(validationResult.error);
@@ -48,6 +51,9 @@ module.exports = function(conf){
       }
       
       renderComponents(components, options, callback);
+    },
+    getComponentsInfo: function(components, callback) {
+      getComponentsInfo(components, callback);
     },
     renderTemplate: renderTemplate
   };

--- a/client/src/sanitiser.js
+++ b/client/src/sanitiser.js
@@ -15,6 +15,27 @@ var lowerHeaderKeys = function(headers){
   return result;
 };
 
+var getDefaultUserAgent = function() {
+  return format('oc-client-{0}/{1}-{2}-{3}',
+                packageInfo.version,
+                process.version,
+                process.platform,
+                process.arch);
+};
+
+var sanitiseDefaultOptions = function(options) {
+  if(_.isFunction(options)){
+      options = {};
+    }
+
+    options = options || {};
+    options.headers = lowerHeaderKeys(options.headers);
+    options.headers['user-agent'] = options.headers['user-agent'] || getDefaultUserAgent();
+
+    options.timeout = options.timeout || 5;
+    return options;
+};
+
 module.exports = {
   sanitiseConfiguration: function(conf){
     conf = conf || {};
@@ -23,25 +44,11 @@ module.exports = {
 
     return conf;
   },
+
   sanitiseGlobalRenderOptions: function(options, config){
-
-    if(_.isFunction(options)){
-      options = {};
-    }
-
-    var defaultUserAgent = format('oc-client-{0}/{1}-{2}-{3}',
-                                  packageInfo.version,
-                                  process.version,
-                                  process.platform,
-                                  process.arch);
-
-    options = options || {};
-    
-    options.headers = lowerHeaderKeys(options.headers);
+    options = sanitiseDefaultOptions(options);
     options.headers.accept = 'application/vnd.oc.unrendered+json';
-    options.headers['user-agent'] = options.headers['user-agent'] || defaultUserAgent;
 
-    options.timeout = options.timeout || 5;
     options.container = (options.container === true) ?  true : false;
     options.renderInfo = (options.renderInfo === false) ? false : true;
 
@@ -49,6 +56,12 @@ module.exports = {
       options.disableFailoverRendering = true;
     }
 
+    return options;
+  },
+
+  sanitiseGlobalGetInfoOptions: function(options, config) {
+    options = sanitiseDefaultOptions(options);
+    options.headers.accept = 'application/vnd.oc.info+json';
     return options;
   }
 };

--- a/client/src/settings.js
+++ b/client/src/settings.js
@@ -10,5 +10,6 @@ module.exports = {
   registriesEmpty: 'registries must contain at least one endpoint',
   registriesIsNotObject: 'registries must be an object',
   serverSideRenderingFail: 'Server-side rendering failed: {0}',
+  componentGetInfoFail: 'Getting component info failed: {0}',
   warmupFailed: 'Error warming up oc-client: request {0} failed ({1})'
 };

--- a/src/registry/routes/component.js
+++ b/src/registry/routes/component.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var GetComponentHelper = require('./helpers/get-component');
-var Settings = require('../../resources/settings');
 
 module.exports = function(conf, repository){
 

--- a/src/registry/routes/component.js
+++ b/src/registry/routes/component.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var GetComponentHelper = require('./helpers/get-component');
+var Settings = require('../../resources/settings');
 
 module.exports = function(conf, repository){
 

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -129,6 +129,7 @@ module.exports = function(conf, repository){
         }, conf.baseUrl);
 
         var isUnrendered = options.headers.accept === settings.registry.acceptUnrenderedHeader,
+            skipRendering = options.headers.accept === settings.registry.acceptInfoHeader,
             renderMode = isUnrendered ? 'unrendered' : 'rendered';
 
         var response = {
@@ -149,7 +150,12 @@ module.exports = function(conf, repository){
           renderMode: renderMode
         });
 
-        if(isUnrendered){
+        if (skipRendering) {
+          callback({
+            status: 200,
+            response: response
+          });
+        } else if (isUnrendered) {
           callback({
             status: 200,
             response: _.extend(response, {

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -76,6 +76,19 @@ module.exports = function(conf, repository){
         });
       }
 
+      // Skip rendering and return only the component info in case of 'accept: application/vnd.oc.info+json'
+      if (options.headers.accept === settings.registry.acceptInfoHeader) {
+        return callback({
+          status: 200,
+          response: {
+            type: conf.local ? 'oc-component-local' : 'oc-component',
+            version: component.version,
+            requestVersion: requestedComponent.version,
+            name: requestedComponent.name,
+          }
+        });
+      }
+
       // check component requirements are satisfied by registry      
       var pluginsCompatibility = validator.validatePluginsRequirements(component.oc.plugins, conf.plugins);
 
@@ -129,7 +142,6 @@ module.exports = function(conf, repository){
         }, conf.baseUrl);
 
         var isUnrendered = options.headers.accept === settings.registry.acceptUnrenderedHeader,
-            skipRendering = options.headers.accept === settings.registry.acceptInfoHeader,
             renderMode = isUnrendered ? 'unrendered' : 'rendered';
 
         var response = {
@@ -150,12 +162,7 @@ module.exports = function(conf, repository){
           renderMode: renderMode
         });
 
-        if (skipRendering) {
-          callback({
-            status: 200,
-            response: response
-          });
-        } else if (isUnrendered) {
+        if (isUnrendered) {
           callback({
             status: 200,
             response: _.extend(response, {

--- a/src/resources/settings.js
+++ b/src/resources/settings.js
@@ -8,6 +8,7 @@ module.exports = {
   registry: {
     acceptRenderedHeader: 'application/vnd.oc.rendered+json',
     acceptUnrenderedHeader: 'application/vnd.oc.unrendered+json',
+    acceptInfoHeader: 'application/vnd.oc.info+json',
     componentInfoPath: '/~info',
     componentPreviewPath: '/~preview',
     defaultTempPath: './temp/',

--- a/test/acceptance/client.js
+++ b/test/acceptance/client.js
@@ -391,9 +391,7 @@ describe('The node.js OC client', function(){
         componentName: 'hello-world',
         requestedVersion: undefined,
         apiResponse: {
-          href: 'http://localhost:3030/hello-world',
           name: 'hello-world',
-          renderMode: 'rendered',
           requestVersion: '',
           type: 'oc-component-local',
           version: '1.0.0'
@@ -402,9 +400,7 @@ describe('The node.js OC client', function(){
         componentName: 'no-containers',
         requestedVersion: '1.x.x',
         apiResponse: {
-          href: 'http://localhost:3030/no-containers/1.x.x',
           name: 'no-containers',
-          renderMode: 'rendered',
           requestVersion: '1.x.x',
           type: 'oc-component-local',
           version: '1.0.0'
@@ -453,9 +449,7 @@ describe('The node.js OC client', function(){
           componentName: 'hello-world',
           requestedVersion: undefined,
           apiResponse: {
-            href: 'http://localhost:3030/hello-world',
             name: 'hello-world',
-            renderMode: 'rendered',
             requestVersion: '',
             type: 'oc-component-local',
             version: '1.0.0'

--- a/test/acceptance/client.js
+++ b/test/acceptance/client.js
@@ -50,7 +50,9 @@ describe('The node.js OC client', function(){
       registry.start(done);
     });
 
-    after(function(done){ registry.close(done); });
+    after(function(done){ 
+      registry.close(done); 
+    });
 
     describe('when rendering 2 components', function(){
       describe('when components require params', function(){
@@ -367,6 +369,118 @@ describe('The node.js OC client', function(){
         expect($component.attr('href')).to.equal('http://localhost:1234/hello-world/~1.0.0');
       });
     });
+
+    describe('when getting components info for 2 existing component', function() {
+      var error;
+      var info;
+
+      before(function(done){
+        client.getComponentsInfo([{
+          name: 'hello-world'
+        }, {
+          name: 'no-containers',
+          version: '1.x.x'
+        }], function($error, $info) {
+          error = $error;
+          info = $info;
+          done();
+        });
+      });
+
+      var expectedInfo = [{
+        componentName: 'hello-world',
+        requestedVersion: undefined,
+        apiResponse: {
+          href: 'http://localhost:3030/hello-world',
+          name: 'hello-world',
+          renderMode: 'rendered',
+          requestVersion: '',
+          type: 'oc-component-local',
+          version: '1.0.0'
+        }
+      }, {
+        componentName: 'no-containers',
+        requestedVersion: '1.x.x',
+        apiResponse: {
+          href: 'http://localhost:3030/no-containers/1.x.x',
+          name: 'no-containers',
+          renderMode: 'rendered',
+          requestVersion: '1.x.x',
+          type: 'oc-component-local',
+          version: '1.0.0'
+        }
+      }];
+
+      it('should return valid info', function() {
+        expect(error).to.be.null();
+        expect(info).to.be.deep.equal(expectedInfo);
+      });
+
+    });
+
+    describe('when getting components info for 1 existing, 1 with higher version and 1 non-existing components', function() {
+      var error;
+      var info;
+
+      before(function(done){
+        client.getComponentsInfo([{
+          name: 'hello-world'
+        }, {
+          name: 'no-containers',
+          version: '3.5.7'
+        }, {
+          name: 'non-existing',
+          version: '1.x.x'
+        }], function($error, $info) {
+          error = $error;
+          info = $info;
+          done();
+        });
+      });
+
+      it('should return both valid info and error', function() {
+        expect(error).to.be.ok;
+        expect(error).to.be.instanceof(Array);
+        expect(error.length).to.be.equal(3);
+
+        expect(info).to.be.ok;
+        expect(info).to.be.instanceof(Array);
+        expect(info.length).to.be.equal(3);
+      });
+
+      it('should return correct info for the 1st component', function() {
+        var expectedFirstComponentInfo = [{
+          componentName: 'hello-world',
+          requestedVersion: undefined,
+          apiResponse: {
+            href: 'http://localhost:3030/hello-world',
+            name: 'hello-world',
+            renderMode: 'rendered',
+            requestVersion: '',
+            type: 'oc-component-local',
+            version: '1.0.0'
+          }
+        }];
+
+        expect(info[0]).to.be.deep.equal(expectedFirstComponentInfo[0]);
+      });
+
+      it('should return info with errors for the 2nd and 3rd component', function(){
+        expect(info[1].componentName).to.be.equal('no-containers');
+        expect(info[1].requestedVersion).to.be.equal('3.5.7');
+        expect(info[1].error.message).to.be.equal('Getting component info failed: Component "no-containers" with version "3.5.7" not found on local repository (404)');
+
+        expect(info[2].componentName).to.be.equal('non-existing');
+        expect(info[2].requestedVersion).to.be.equal('1.x.x');
+        expect(info[2].error.message).to.be.equal('Getting component info failed: Component "non-existing" not found on local repository (404)');
+      });
+
+      it('should return error array with errors for the 2nd and 3rd components', function() {
+        expect(error[0]).to.not.be.ok;
+        expect(error[1].message).to.be.equal('Getting component info failed: Component "no-containers" with version "3.5.7" not found on local repository (404)');
+        expect(error[2].message).to.be.equal('Getting component info failed: Component "non-existing" not found on local repository (404)');
+      });
+    });
   });
 
   describe('when correctly initialised', function(){
@@ -387,9 +501,9 @@ describe('The node.js OC client', function(){
       var expectedRequest = {
         url: 'http://localhost:1234',
         method: 'post',
-        headers: { 
-          accept: 'application/vnd.oc.unrendered+json',
-          'user-agent': 'oc-client-(.*?)'
+        headers: {
+          'user-agent': 'oc-client-(.*?)',
+          'accept': 'application/vnd.oc.unrendered+json'
         },
         timeout: 5,
         json: true,
@@ -425,7 +539,8 @@ describe('The node.js OC client', function(){
           var exp = getRegExpFromJson(expectedRequest),
               expected = new RegExp('Error: Server-side rendering failed: request ' + exp + ' failed \\(Error: connect ECONNREFUSED(.*?)\\)');
 
-          expect(error.toString()).to.match(expected);
+          var actual = error.toString();
+          expect(actual).to.match(expected);
         });
       });
 
@@ -507,8 +622,8 @@ describe('The node.js OC client', function(){
             method: 'post',
             headers: {
               'accept-language': 'da, en-gb;q=0.8, en;q=0.7',
-              accept: 'application/vnd.oc.unrendered+json',
-              'user-agent': 'oc-client-(.*?)'
+              'user-agent': 'oc-client-(.*?)',
+              'accept': 'application/vnd.oc.unrendered+json',
             },
             timeout: 5,
             json: true,
@@ -580,9 +695,9 @@ describe('The node.js OC client', function(){
         var expectedRequest = {
           url: 'http://localhost:3030',
           method: 'post',
-          headers: { 
-            accept: 'application/vnd.oc.unrendered+json',
-            'user-agent': 'oc-client-(.*?)'
+          headers: {
+            'user-agent': 'oc-client-(.*?)',
+            'accept': 'application/vnd.oc.unrendered+json',
           },
           timeout: 0.01,
           json: true,
@@ -671,5 +786,69 @@ describe('The node.js OC client', function(){
         });
       });
     });
+
+    describe('when getting components info with a non responsive registry', function() {
+      var error;
+      var info;
+
+      before(function(done){
+        clientOfflineRegistry.getComponentsInfo([{
+          name: 'hello-world'
+        },{
+          name: 'other-component',
+          version: '1.0.0'
+        }], function($error, $info) {
+          error = $error;
+          info = $info;
+          done();
+        });
+      });
+
+      var expectedRequest = {
+        url: 'http://localhost:1234',
+        method: 'post',
+        headers: {
+          'user-agent': 'oc-client-(.*?)',
+          'accept': 'application/vnd.oc.info+json'
+        },
+        timeout: 5,
+        json: true,
+        body: {
+          components: [{
+            name: 'hello-world'
+          },{
+            name: 'other-component',
+            version: '1.0.0'
+          }]
+        }
+      };
+
+      var exp = getRegExpFromJson(expectedRequest);
+      var expectedError = new RegExp('Getting component info failed: request ' + exp + ' failed \\(Error: connect ECONNREFUSED(.*?)\\)');
+
+      it('should fail and return an errors array with an error corresponding to every component requested', function() {
+        expect(error).to.not.be.undefined();
+        expect(error).to.be.instanceof(Array);
+        expect(error.length).to.be.equal(2);
+        
+        expect(error[0]).to.match(expectedError);
+        expect(error[1]).to.match(expectedError);
+      });
+
+      it('return an info array with components requested together with an error for every component', function() {
+        expect(info).to.not.be.undefined();
+        expect(info).to.be.instanceof(Array);
+        expect(info.length).to.be.equal(2);
+
+        expect(info[0].componentName).to.be.equal('hello-world');
+        expect(info[0].requestedVersion).to.be.undefined();
+        expect(info[0].error).to.match(expectedError);
+
+        expect(info[1].componentName).to.be.equal('other-component');
+        expect(info[1].requestedVersion).to.be.equal('1.0.0');
+        expect(info[1].error).to.match(expectedError);
+      });
+    });
+
   });
 });

--- a/test/unit/registry-routes-component.js
+++ b/test/unit/registry-routes-component.js
@@ -565,4 +565,53 @@ describe('registry : routes : component', function(){
     });
   });
 
+  describe('when getting a component info for a component that sets custom headers', function() {
+    var code, response, headers;
+
+    before(function(done) {
+      initialise(mockedComponents['response-headers-component']);
+      componentRoute = new ComponentRoute({}, mockedRepository);
+
+      var resJson = function(calledCode, calledResponse) {
+        code = calledCode;
+        response = calledResponse;
+        done();
+      };
+
+      var resSet = function(calledHeaders) {
+        headers = calledHeaders;
+      };
+
+      componentRoute({
+        headers: { accept: 'application/vnd.oc.info+json' },
+        params: { componentName: 'response-headers-component', componentVersion: '1.0.0' }
+      }, {
+        conf: {
+          baseUrl: 'http://component.com/',
+          executionTimeout: 0.1
+        },
+        json: resJson,
+        set: resSet
+      });
+    });
+
+    it('should return 200 status code', function() {
+      expect(code).to.be.equal(200);
+    });
+
+    it('should return no custom headers', function() {
+      expect(response.headers).to.be.undefined;
+      expect(headers).to.be.undefined;
+    });
+
+    it('should return component\'s name and request version', function() {
+      expect(response.name).to.equal('response-headers-component');
+      expect(response.requestVersion).to.equal('1.0.0');
+    });
+
+    it('should not return rendered HTML', function() {
+      expect(response.html).to.be.undefined;
+    });
+  });
+
 });

--- a/test/unit/registry-routes-components.js
+++ b/test/unit/registry-routes-components.js
@@ -124,8 +124,7 @@ describe('registry : routes : components', function(){
       makeInfoRequest({
         components: [{
           name: 'async-error2-component',
-          version: '1.X.X',
-          parameters: { error: true }
+          version: '1.X.X'
         }, {
           name: 'async-error2-component',
           version: '1.0.0'
@@ -141,37 +140,26 @@ describe('registry : routes : components', function(){
       expect(response.length).to.be.equal(2);
     });
 
+    var expectedResponse = [{
+        status: 200,
+        response: {
+          name: 'async-error2-component',
+          type: 'oc-component',
+          requestVersion: '1.X.X',
+          version: '1.0.0',
+        }
+      }, {
+        status: 200,
+        response: {
+          name: 'async-error2-component',
+          type: 'oc-component',
+          requestVersion: '1.0.0',
+          version: '1.0.0',
+        }
+      }];
+
     it('should return a response containing components in the correct order', function(){
-      expect(response[0].response.href).to.be.undefined;
-      expect(response[1].response.href).to.be.equal('http://components.com/async-error2-component/1.0.0');
-    });
-
-    it('should return a response with error code and description for the first component', function(){
-      expect(response[0].response.code).to.be.equal('GENERIC_ERROR');
-      expect(response[0].response.error).to.be.equal('Component execution error: thisDoesnotExist is not defined');
-    });
-
-    it('should not return a response with rendered html for the second component', function(){
-      expect(response[1].response.html).to.be.undefined;
-    });
-
-    it('should include 500 status code for first component', function(){
-      expect(response[0].status).to.equal(500);
-    });
-
-    it('should include 200 status code for second component', function(){
-      expect(response[1].status).to.equal(200);
-    });
-
-    it('should return name and request version for both components', function(){
-      expect(response[0].response.name).to.be.equal('async-error2-component');
-      expect(response[0].response.requestVersion).to.be.equal('1.X.X');
-      expect(response[1].response.name).to.be.equal('async-error2-component');
-      expect(response[1].response.requestVersion).to.be.equal('1.0.0');
-    });
-
-    it('should rerurn the actual version for the second component', function() {
-      expect(response[1].response.version).to.be.equal('1.0.0');
+      expect(response).to.be.eql(expectedResponse);
     });
   });
 

--- a/test/unit/registry-routes-components.js
+++ b/test/unit/registry-routes-components.js
@@ -33,6 +33,17 @@ describe('registry : routes : components', function(){
     });
   };
 
+  var makeInfoRequest = function(body, cb){
+    componentsRoute({ headers: { accept: 'application/vnd.oc.info+json' }, body: body }, {
+      conf: { baseUrl: 'http://components.com/' },
+      json: function(jsonCode, jsonResponse){
+        response = jsonResponse;
+        code = jsonCode;
+        cb();
+      }
+    });
+  };
+
   describe('when making valid request for two components', function(){
 
     before(function(done){
@@ -93,6 +104,81 @@ describe('registry : routes : components', function(){
 
     before(function(done){
       makeRequest({ components: []}, done);
+    });
+
+    it('should return 200 status code', function(){
+      expect(code).to.be.equal(200);
+    });
+
+    it('should return a response containing empty array', function(){
+      expect(response).to.be.eql([]);
+    });
+  });
+
+  describe('when making valid info request for two components', function(){
+
+    before(function(done){
+      initialise(mockedComponents['async-error2-component']);
+      componentsRoute = new ComponentsRoute({}, mockedRepository);
+
+      makeInfoRequest({
+        components: [{
+          name: 'async-error2-component',
+          version: '1.X.X',
+          parameters: { error: true }
+        }, {
+          name: 'async-error2-component',
+          version: '1.0.0'
+        }]
+      }, done);
+    });
+
+    it('should return 200 status code', function(){
+      expect(code).to.be.equal(200);
+    });
+
+    it('should return a response containing both components', function(){
+      expect(response.length).to.be.equal(2);
+    });
+
+    it('should return a response containing components in the correct order', function(){
+      expect(response[0].response.href).to.be.undefined;
+      expect(response[1].response.href).to.be.equal('http://components.com/async-error2-component/1.0.0');
+    });
+
+    it('should return a response with error code and description for the first component', function(){
+      expect(response[0].response.code).to.be.equal('GENERIC_ERROR');
+      expect(response[0].response.error).to.be.equal('Component execution error: thisDoesnotExist is not defined');
+    });
+
+    it('should not return a response with rendered html for the second component', function(){
+      expect(response[1].response.html).to.be.undefined;
+    });
+
+    it('should include 500 status code for first component', function(){
+      expect(response[0].status).to.equal(500);
+    });
+
+    it('should include 200 status code for second component', function(){
+      expect(response[1].status).to.equal(200);
+    });
+
+    it('should return name and request version for both components', function(){
+      expect(response[0].response.name).to.be.equal('async-error2-component');
+      expect(response[0].response.requestVersion).to.be.equal('1.X.X');
+      expect(response[1].response.name).to.be.equal('async-error2-component');
+      expect(response[1].response.requestVersion).to.be.equal('1.0.0');
+    });
+
+    it('should rerurn the actual version for the second component', function() {
+      expect(response[1].response.version).to.be.equal('1.0.0');
+    });
+  });
+
+  describe('when making info request for 0 components', function(){
+
+    before(function(done){
+      makeInfoRequest({ components: []}, done);
     });
 
     it('should return 200 status code', function(){


### PR DESCRIPTION
1. Changed the registry to anticipate 'Accept: application/vnd.oc.info+json'
HTTP header and if detects it to skip the component rendering and to return
the component's info only.

2. Added a new method in the Client - getComponentsInfo(...)
It prepares the request to the registry with proper accept headers, checks
for errors and provides a processed result pair (error[], info[]).
- in case info data is provided for all the requested components then the error
will be null and the info will have the following structure:
[{
   componentName: '<name>',
   requestedVersion: '<requested version|undefined>'
   apiResponse: {  //// comes from the registry
      href: '<component url>',
      name: '<name>',
      renderMode: '<rendered|unrendered>',
      requestVersion: <requested version>,
      type: '<type>',
      version: '<actual version>'
   }
},
{
   componentName: '<name>',
   requestedVersion: '<requested version|undefined>'
   apiResponse: {...}
},
...
]

- in case of errors then the info part will skip the apiResponse and will
include an error field:
{
   componentName: '<name>',
   requestedVersion: '<requested version|undefined>'
   error: ...
}

In addition to this the 'error' will be an array holding the
errors corresponding to each component requested. If there's no
error for a particular component then the corresponding element in the 'error'
array will be null:
[
   null,  //// means the first component is OK
   { message: ..., stackTrace: ... },
   null,  //// third components is OK as well
   ...
]