### PR TITLE
333 - Implement customHeadersToSkipOnWeakVersion functionality

### DIFF
--- a/src/registry/domain/options-sanitiser.js
+++ b/src/registry/domain/options-sanitiser.js
@@ -37,6 +37,9 @@ module.exports = function(input){
     options.verbosity = 0;
   }
 
+  options.customHeadersToSkipOnWeakVersion = (options.customHeadersToSkipOnWeakVersion || [])
+    .map(function(s) { return s.toLowerCase(); });
+
   options.port = process.env.PORT || options.port;
 
   return options;

--- a/src/registry/domain/validators/registry-configuration.js
+++ b/src/registry/domain/validators/registry-configuration.js
@@ -71,5 +71,19 @@ module.exports = function(conf){
     }
   }
 
+  if (conf.customHeadersToSkipOnWeakVersion) {
+    if (!_.isArray(conf.customHeadersToSkipOnWeakVersion)) {
+      return returnError(strings.errors.registry.CONFIGURATION_HEADERS_TO_SKIP_MUST_BE_STRING_ARRAY);
+    }
+
+    var hasNonStringElements = conf.customHeadersToSkipOnWeakVersion.find(function(element) {
+      return typeof(element) !== 'string';
+    });
+
+    if (hasNonStringElements) {
+      return returnError(strings.errors.registry.CONFIGURATION_HEADERS_TO_SKIP_MUST_BE_STRING_ARRAY);
+    }
+  }
+
   return response;
 };

--- a/src/registry/routes/component.js
+++ b/src/registry/routes/component.js
@@ -7,20 +7,6 @@ module.exports = function(conf, repository){
 
   var getComponent = new GetComponentHelper(conf, repository);
 
-  var setCustomHeaders = function(req, res, componentResponse) {
-    var headersToSet = componentResponse.headers;
-
-    if (req.params.componentVersion !== componentResponse.version && 
-        !_.isEmpty(res.conf.customHeadersToSkipOnWeakVersion)) 
-    {
-      headersToSet = _.omit(headersToSet, res.conf.customHeadersToSkipOnWeakVersion);
-    }
-    
-    if (!_.isEmpty(headersToSet)) {
-      res.set(headersToSet);
-    }
-  };
-
   return function(req, res){
     getComponent({
       conf: res.conf,
@@ -34,8 +20,12 @@ module.exports = function(conf, repository){
         res.errorDetails = result.response.error;
       }
 
-      if (result.response.headers) {
-        setCustomHeaders(req, res, result.response);
+      if (!_.isEmpty(result.response.headers)) {
+        res.set(result.response.headers);
+        
+        if (req.method === 'GET') {
+          delete result.response.headers;
+        }
       }
 
       return res.json(result.status, result.response);

--- a/src/registry/routes/component.js
+++ b/src/registry/routes/component.js
@@ -1,10 +1,31 @@
 'use strict';
 
 var GetComponentHelper = require('./helpers/get-component');
+var _ = require('underscore');
 
 module.exports = function(conf, repository){
 
   var getComponent = new GetComponentHelper(conf, repository);
+
+  var setCustomHeaders = function(req, res, componentResponse) {
+    if (req.params.componentVersion === componentResponse.version) {
+      //strong version request
+      res.set(componentResponse.headers);
+    } else {
+      //weak version request, therefore skip the blacklisted headers if any
+      if (_.isEmpty(res.conf.customHeadersToSkipOnWeakVersion || [])) {
+          res.set(componentResponse.headers);
+      } else {
+        var headersToSkip = new Set(res.conf.customHeadersToSkipOnWeakVersion);
+
+        _.forEach(Object.keys(componentResponse.headers), function(header) {
+          if (!headersToSkip.has(header.toLowerCase())) {
+            res.set(header, componentResponse.headers[header]);
+          }
+        });
+      }
+    }
+  };
 
   return function(req, res){
     getComponent({
@@ -20,7 +41,7 @@ module.exports = function(conf, repository){
       }
 
       if (result.response.headers) {
-        res.set(result.response.headers);
+        setCustomHeaders(req, res, result.response);
       }
 
       return res.json(result.status, result.response);

--- a/src/registry/routes/component.js
+++ b/src/registry/routes/component.js
@@ -8,22 +8,16 @@ module.exports = function(conf, repository){
   var getComponent = new GetComponentHelper(conf, repository);
 
   var setCustomHeaders = function(req, res, componentResponse) {
-    if (req.params.componentVersion === componentResponse.version) {
-      //strong version request
-      res.set(componentResponse.headers);
-    } else {
-      //weak version request, therefore skip the blacklisted headers if any
-      if (_.isEmpty(res.conf.customHeadersToSkipOnWeakVersion || [])) {
-          res.set(componentResponse.headers);
-      } else {
-        var headersToSkip = new Set(res.conf.customHeadersToSkipOnWeakVersion);
+    var headersToSet = componentResponse.headers;
 
-        _.forEach(Object.keys(componentResponse.headers), function(header) {
-          if (!headersToSkip.has(header.toLowerCase())) {
-            res.set(header, componentResponse.headers[header]);
-          }
-        });
-      }
+    if (req.params.componentVersion !== componentResponse.version && 
+        !_.isEmpty(res.conf.customHeadersToSkipOnWeakVersion)) 
+    {
+      headersToSet = _.omit(headersToSet, res.conf.customHeadersToSkipOnWeakVersion);
+    }
+    
+    if (!_.isEmpty(headersToSet)) {
+      res.set(headersToSet);
     }
   };
 

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -118,6 +118,16 @@ module.exports = function(conf, repository){
         });
       }
 
+      var filterCustomHeaders = function(headers, requestedVersion, actualVersion) {
+        if (!_.isEmpty(headers) &&
+            !_.isEmpty(conf.customHeadersToSkipOnWeakVersion) &&
+            requestedVersion !== actualVersion) 
+        {
+          headers = _.omit(headers, conf.customHeadersToSkipOnWeakVersion);
+        }
+        return headers;
+      };
+
       var returnComponent = function(err, data){
 
         if(componentCallbackDone){ return; }
@@ -162,6 +172,13 @@ module.exports = function(conf, repository){
           renderMode: renderMode
         });
 
+        if (responseHeaders) {
+          responseHeaders = filterCustomHeaders(responseHeaders, requestedComponent.version, component.version);
+          if (!_.isEmpty(responseHeaders)) {
+            response.headers = responseHeaders;
+          }
+        }
+
         if (isUnrendered) {
           callback({
             status: 200,
@@ -200,10 +217,6 @@ module.exports = function(conf, repository){
                     error: err
                   }
                 });
-              }
-
-              if (responseHeaders) {
-                response.headers = responseHeaders;
               }
 
               callback({

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -245,8 +245,14 @@ module.exports = function(conf, repository){
               requestHeaders: options.headers,
               staticPath: repository.getStaticFilePath(component.name, component.version, '').replace('https:', ''),
               setHeader: function(header, value) {
-                responseHeaders = responseHeaders || {};
-                responseHeaders[header] = value;
+                if (!(typeof(header) === 'string' && typeof(value) === 'string')) {
+                  throw strings.errors.registry.COMPONENT_SET_HEADER_PARAMETERS_NOT_VALID;
+                }
+
+                if (header && value) {
+                  responseHeaders = responseHeaders || {};
+                  responseHeaders[header.toLowerCase()] = value;
+                }
               }
             };
 

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -37,6 +37,7 @@ module.exports = {
       CONFIGURATION_ROUTES_NOT_VALID: 'Registry configuration is not valid: each route should contain route, method and handler',
       CONFIGURATION_ROUTES_MUST_BE_ARRAY: 'Registry configuration is not valid: routes must be an array',
       CONFIGURATION_S3_NOT_VALID: 'Registry configuration is not valid: S3 configuration is not valid',
+      CONFIGURATION_HEADERS_TO_SKIP_MUST_BE_STRING_ARRAY: 'Registry configuration is not valid: customHeadersToSkipOnWeakVersion must be an array of strings',
       DATA_OBJECT_IS_UNDEFINED: 'data object is undefined',
       DEPENDENCY_NOT_FOUND: 'Component is trying to use unavailable dependencies: {0}',
       DEPENDENCY_NOT_FOUND_CODE: 'DEPENDENCY_MISSING_FROM_REGISTRY',

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -26,6 +26,7 @@ module.exports = {
       COMPONENT_VERSION_ALREADY_FOUND_CODE: 'already_exists',
       COMPONENT_VERSION_NOT_VALID: 'Version "{0}" is not a valid semantic version.',
       COMPONENT_VERSION_NOT_VALID_CODE: 'version_not_valid',
+      COMPONENT_SET_HEADER_PARAMETERS_NOT_VALID: 'context.setHeader parameters must be strings',
       CONFIGURATION_DEPENDENCIES_MUST_BE_ARRAY: 'Registry configuration is not valid: dependencies must be an array',
       CONFIGURATION_EMPTY: 'Registry configuration is empty',
       CONFIGURATION_ONREQUEST_MUST_BE_FUNCTION: 'Registry configuration is not valid: registry.on\'s callback must be a function',

--- a/test/acceptance/registry.js
+++ b/test/acceptance/registry.js
@@ -103,7 +103,7 @@ describe('registry', function(){
       it('should return the component with custom headers', function() {
         expect(result.version).to.equal('1.0.0');
         expect(result.name).to.equal('hello-world-custom-headers');
-        expect(result.headers).to.eql({'Cache-Control': 'public max-age=3600', 'Test-Header': 'Test-Value'});
+        expect(result.headers).to.eql({'cache-control': 'public max-age=3600', 'test-header': 'Test-Value'});
         expect(headers).to.have.property('cache-control', 'public max-age=3600');
         expect(headers).to.have.property('test-header', 'Test-Value');
       });
@@ -120,7 +120,7 @@ describe('registry', function(){
       it('should return the component with custom headers', function() {
         expect(result.version).to.equal('1.0.0');
         expect(result.name).to.equal('hello-world-custom-headers');
-        expect(result.headers).to.eql({'Cache-Control': 'public max-age=3600', 'Test-Header': 'Test-Value'});
+        expect(result.headers).to.eql({'cache-control': 'public max-age=3600', 'test-header': 'Test-Value'});
         expect(headers).to.have.property('cache-control', 'public max-age=3600');
         expect(headers).to.have.property('test-header', 'Test-Value');
       });
@@ -156,7 +156,7 @@ describe('registry', function(){
         it('should return the component with the custom headers', function() {
           expect(result.version).to.equal('1.0.0');
           expect(result.name).to.equal('hello-world-custom-headers');
-          expect(result.headers).to.eql({'Cache-Control': 'public max-age=3600', 'Test-Header': 'Test-Value'});
+          expect(result.headers).to.eql({'cache-control': 'public max-age=3600', 'test-header': 'Test-Value'});
           expect(headers).to.have.property('cache-control', 'public max-age=3600');
           expect(headers).to.have.property('test-header', 'Test-Value');
         });
@@ -173,7 +173,7 @@ describe('registry', function(){
         it('should skip Cache-Control header', function() {
           expect(result.version).to.equal('1.0.0');
           expect(result.name).to.equal('hello-world-custom-headers');
-          expect(result.headers).to.eql({'Cache-Control': 'public max-age=3600', 'Test-Header': 'Test-Value'});
+          expect(result.headers).to.eql({'cache-control': 'public max-age=3600', 'test-header': 'Test-Value'});
           expect(headers).to.not.have.property('cache-control');
           expect(headers).to.have.property('test-header', 'Test-Value');
         });

--- a/test/acceptance/registry.js
+++ b/test/acceptance/registry.js
@@ -4,6 +4,7 @@ var expect = require('chai').expect;
 var path = require('path');
 var request = require('minimal-request');
 var url = require('url');
+var _ = require('underscore');
 
 describe('registry', function(){
 
@@ -15,16 +16,16 @@ describe('registry', function(){
       conf;
 
   var next = function(done){
-    return function(e, r, h){
+    return function(e, r, d){
       error = e;
       result = r;
-      headers = h;
+      headers = d.response.headers;
       done();
     };
   };
 
-  before(function(done){
-    conf = {
+  var getDefaultTestConfiguration = function() {
+    return {
       local: true,
       path: path.resolve('test/fixtures/components'),
       port: 3030,
@@ -33,9 +34,15 @@ describe('registry', function(){
       verbosity: 0,
       dependencies: ['underscore']
     };
+  };
 
-    registry = new oc.Registry(conf);
-    registry.start(done);
+  var initializeRegistry = function(configuration, cb) {
+    registry = new oc.Registry(configuration);
+    registry.start(cb);
+  };
+
+  before(function(done){
+    initializeRegistry(getDefaultTestConfiguration(), done);
   });
 
   after(function(done){ registry.close(done); });
@@ -53,48 +60,9 @@ describe('registry', function(){
 
   describe('GET /hello-world-custom-headers', function() {
 
-    var httpGetRequest = function(options, callback) {
-      var callbackDone = false;
-      var requestData = url.parse(options.url);
-      requestData.headers = options.headers || {};
-      requestData.method = 'get';
-
-      var req = require('http').request(requestData).on('response', function(response) {
-        var body = [];
-
-        response.on('data', function(chunk){
-          body.push(chunk);
-        }).on('end', function(){
-          body = Buffer.concat(body);
-
-          if(!callbackDone){
-            callbackDone = true;
-            var error = response.statusCode !== 200 ? response.statusCode : null;
-
-            if (options.json) {
-              try {
-                callback(error, JSON.parse(body), response.headers);
-              } catch(e){
-                return callback('json parsing error');
-              }
-            } else {
-              callback(error, body, response.headers);
-            }
-          }
-        });
-      }).on('error', function(e){
-        if(!callbackDone){
-          callbackDone = true;
-          callback(e);
-        }
-      });
-
-      req.end();
-    };
-
     describe('with the default configuration (no customHeadersToSkipOnWeakVersion defined) and strong version 1.0.0', function() {
       before(function(done) {
-        httpGetRequest({
+        request({
           url: 'http://localhost:3030/hello-world-custom-headers/1.0.0',
           json: true
         }, next(done));
@@ -103,7 +71,7 @@ describe('registry', function(){
       it('should return the component with custom headers', function() {
         expect(result.version).to.equal('1.0.0');
         expect(result.name).to.equal('hello-world-custom-headers');
-        expect(result.headers).to.eql({'cache-control': 'public max-age=3600', 'test-header': 'Test-Value'});
+        expect(result.headers).to.be.undefined;
         expect(headers).to.have.property('cache-control', 'public max-age=3600');
         expect(headers).to.have.property('test-header', 'Test-Value');
       });
@@ -111,7 +79,7 @@ describe('registry', function(){
 
     describe('with the default configuration (no customHeadersToSkipOnWeakVersion defined) and weak version 1.x.x', function() {
       before(function(done) {
-        httpGetRequest({
+        request({
           url: 'http://localhost:3030/hello-world-custom-headers/1.x.x',
           json: true
         }, next(done));
@@ -120,7 +88,7 @@ describe('registry', function(){
       it('should return the component with custom headers', function() {
         expect(result.version).to.equal('1.0.0');
         expect(result.name).to.equal('hello-world-custom-headers');
-        expect(result.headers).to.eql({'cache-control': 'public max-age=3600', 'test-header': 'Test-Value'});
+        expect(result.headers).to.be.undefined;
         expect(headers).to.have.property('cache-control', 'public max-age=3600');
         expect(headers).to.have.property('test-header', 'Test-Value');
       });
@@ -129,25 +97,18 @@ describe('registry', function(){
     describe('with a custom configuration with customHeadersToSkipOnWeakVersion defined', function() {
       before(function(done) {
         registry.close();
+        initializeRegistry(_.extend(getDefaultTestConfiguration(), {customHeadersToSkipOnWeakVersion: ['Cache-Control']}), done);
+      });
 
-        conf = {          
-          local: true,
-          path: path.resolve('test/fixtures/components'),
-          port: 3030,
-          baseUrl: 'http://localhost:3030/',
-          env: { name: 'local' },
-          verbosity: 0,
-          dependencies: ['underscore'],
-          customHeadersToSkipOnWeakVersion: ['Cache-Control']
-        };
-
-        registry = new oc.Registry(conf);
-        registry.start(done);
+      after(function(done){ 
+        registry.close(function() {
+          initializeRegistry(getDefaultTestConfiguration(), done);
+        });
       });
 
       describe('when strong version is requested 1.0.0', function() {
         before(function(done) {
-          httpGetRequest({
+          request({
             url: 'http://localhost:3030/hello-world-custom-headers/1.0.0',
             json: true
           }, next(done));
@@ -156,7 +117,7 @@ describe('registry', function(){
         it('should return the component with the custom headers', function() {
           expect(result.version).to.equal('1.0.0');
           expect(result.name).to.equal('hello-world-custom-headers');
-          expect(result.headers).to.eql({'cache-control': 'public max-age=3600', 'test-header': 'Test-Value'});
+          expect(result.headers).to.be.undefined;
           expect(headers).to.have.property('cache-control', 'public max-age=3600');
           expect(headers).to.have.property('test-header', 'Test-Value');
         });
@@ -164,7 +125,7 @@ describe('registry', function(){
 
       describe('when weak version is requested 1.x.x', function() {
         before(function(done) {
-          httpGetRequest({
+          request({
             url: 'http://localhost:3030/hello-world-custom-headers/1.x.x',
             json: true
           }, next(done));
@@ -173,9 +134,133 @@ describe('registry', function(){
         it('should skip Cache-Control header', function() {
           expect(result.version).to.equal('1.0.0');
           expect(result.name).to.equal('hello-world-custom-headers');
-          expect(result.headers).to.eql({'cache-control': 'public max-age=3600', 'test-header': 'Test-Value'});
+          expect(result.headers).to.be.undefined;
           expect(headers).to.not.have.property('cache-control');
           expect(headers).to.have.property('test-header', 'Test-Value');
+        });
+      });
+    });
+  });
+
+  describe('POST /hello-world-custom-headers', function() {
+
+    describe('with the default configuration (no customHeadersToSkipOnWeakVersion defined) and strong version 1.0.0', function() {
+      before(function(done) {
+        request({
+          url: 'http://localhost:3030',
+          json: true,
+          method: 'post',
+          body: {
+            components: [{
+              name: 'hello-world-custom-headers',
+              version: '1.0.0'
+            }]
+          }
+        }, next(done));
+      });
+
+      it('should not set HTTP custom headers', function() {
+        expect(headers).to.not.have.property('cache-control');
+        expect(headers).to.not.have.property('test-header');
+      });
+
+      it('should return the component with custom headers', function() {
+        expect(result[0].response.version).to.equal('1.0.0');
+        expect(result[0].response.name).to.equal('hello-world-custom-headers');
+        expect(result[0].response.headers).to.be.deep.equal({'cache-control': 'public max-age=3600', 'test-header': 'Test-Value'});
+      });
+    });
+
+    describe('with the default configuration (no customHeadersToSkipOnWeakVersion defined) and weak version 1.x.x', function() {
+      before(function(done) {
+        request({
+          url: 'http://localhost:3030',
+          json: true,
+          method: 'post',
+          body: {
+            components: [{
+              name: 'hello-world-custom-headers',
+              version: '1.x.x'
+            }]
+          }
+        }, next(done));
+      });
+
+      it('should not set HTTP custom headers', function() {
+        expect(headers).to.not.have.property('cache-control');
+        expect(headers).to.not.have.property('test-header');
+      });
+
+      it('should return the component with custom headers in the response body', function() {
+        expect(result[0].response.version).to.equal('1.0.0');
+        expect(result[0].response.name).to.equal('hello-world-custom-headers');
+        expect(result[0].response.headers).to.be.deep.equal({'cache-control': 'public max-age=3600', 'test-header': 'Test-Value'});
+      });
+    });
+
+    describe('with a custom configuration with customHeadersToSkipOnWeakVersion defined', function() {
+      before(function(done) {
+        registry.close();
+        initializeRegistry(_.extend(getDefaultTestConfiguration(), {customHeadersToSkipOnWeakVersion: ['Cache-Control']}), done);
+      });
+
+      after(function(done){ 
+        registry.close(function() {
+          initializeRegistry(getDefaultTestConfiguration(), done);
+        });
+      });
+
+      describe('when strong version is requested 1.0.0', function() {
+        before(function(done) {
+          request({
+            url: 'http://localhost:3030',
+            json: true,
+            method: 'post',
+            body: {
+              components: [{
+                name: 'hello-world-custom-headers',
+                version: '1.0.0'
+              }]
+            }
+          }, next(done));
+        });
+
+        it('should not set HTTP custom headers', function() {
+          expect(headers).to.not.have.property('cache-control');
+          expect(headers).to.not.have.property('test-header');
+        });
+
+        it('should return the component with the custom headers', function() {
+          expect(result[0].response.version).to.equal('1.0.0');
+          expect(result[0].response.name).to.equal('hello-world-custom-headers');
+          expect(result[0].response.headers).to.be.deep.equal({'cache-control': 'public max-age=3600', 'test-header': 'Test-Value'});
+        });
+      });
+
+      describe('when weak version is requested 1.x.x', function() {
+        before(function(done) {
+          request({
+            url: 'http://localhost:3030',
+            json: true,
+            method: 'post',
+            body: {
+              components: [{
+                name: 'hello-world-custom-headers',
+                version: '1.x.x'
+              }]
+            }
+          }, next(done));
+        });
+
+        it('should not set HTTP custom headers', function() {
+          expect(headers).to.not.have.property('cache-control');
+          expect(headers).to.not.have.property('test-header');
+        });
+
+        it('should skip Cache-Control header', function() {
+          expect(result[0].response.version).to.equal('1.0.0');
+          expect(result[0].response.name).to.equal('hello-world-custom-headers');
+          expect(result[0].response.headers).to.be.deep.equal({'test-header': 'Test-Value'});
         });
       });
     });

--- a/test/fixtures/components/hello-world-custom-headers/_package/package.json
+++ b/test/fixtures/components/hello-world-custom-headers/_package/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "hello-world-custom-headers",
+  "description": "",
+  "version": "1.0.0",
+  "repository": "",
+  "oc": {
+    "files": {
+      "template": {
+        "type": "handlebars",
+        "hashKey": "c6fcae4d23d07fd9a7e100508caf8119e998d7a9",
+        "src": "template.js"
+      },
+      "dataProvider": {
+        "type": "node.js",
+        "hashKey": "7101d6bf3279cf05b613d063157077b2b14ca3b2",
+        "src": "server.js"
+      },
+      "static": []
+    },
+    "version": "0.33.30",
+    "packaged": true,
+    "date": 1483635935550
+  }
+}

--- a/test/fixtures/components/hello-world-custom-headers/_package/server.js
+++ b/test/fixtures/components/hello-world-custom-headers/_package/server.js
@@ -1,0 +1,1 @@
+"use strict";module.exports.data=function(e,t){e.setHeader("Test-Header","Test-Value"),e.setHeader("Cache-Control","public max-age=3600"),t(null,{})};

--- a/test/fixtures/components/hello-world-custom-headers/_package/template.js
+++ b/test/fixtures/components/hello-world-custom-headers/_package/template.js
@@ -1,0 +1,1 @@
+var oc=oc||{};oc.components=oc.components||{},oc.components.c6fcae4d23d07fd9a7e100508caf8119e998d7a9={compiler:[7,">= 4.0.0"],main:function(o,c,e,n,a){return"Hello world!"},useData:!0};

--- a/test/fixtures/components/hello-world-custom-headers/package.json
+++ b/test/fixtures/components/hello-world-custom-headers/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hello-world-custom-headers",
+  "description": "",
+  "version": "1.0.0",
+  "repository": "",
+  "oc": {
+    "files": {
+      "data": "server.js",
+      "template": {
+        "src": "template.html",
+        "type": "handlebars"
+      }
+    }
+  }
+}

--- a/test/fixtures/components/hello-world-custom-headers/server.js
+++ b/test/fixtures/components/hello-world-custom-headers/server.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports.data = function(context, callback){
+	context.setHeader('Test-Header', 'Test-Value');
+	context.setHeader('Cache-Control', 'public max-age=3600');
+	callback(null, {});
+};

--- a/test/fixtures/components/hello-world-custom-headers/template.html
+++ b/test/fixtures/components/hello-world-custom-headers/template.html
@@ -1,0 +1,1 @@
+Hello world!

--- a/test/unit/registry-domain-options-sanitiser.js
+++ b/test/unit/registry-domain-options-sanitiser.js
@@ -23,4 +23,23 @@ describe('registry : domain : options-sanitiser', function(){
       expect(sanitise(options).verbosity).to.equal(3);
     });
   });
+
+  describe('customHeadersToSkipOnWeakVersion', function() {
+
+    describe('when customHeadersToSkipOnWeakVersion is undefined', function() {
+      var options = {};
+
+      it('should set it to an empty array', function() {
+        expect(sanitise(options).customHeadersToSkipOnWeakVersion).to.be.eql([]);
+      });
+    });
+
+    describe('when customHeadersToSkipOnWeakVersion contains valid elements', function() {
+      var options = {customHeadersToSkipOnWeakVersion: ['header1', 'HeAdEr-TwO', 'HEADER3']};
+
+      it('should convert the array elements to lower case', function() {
+        expect(sanitise(options).customHeadersToSkipOnWeakVersion).to.be.eql(['header1', 'header-two', 'header3']);
+      });
+    });
+  });
 });

--- a/test/unit/registry-domain-repository.js
+++ b/test/unit/registry-domain-repository.js
@@ -272,6 +272,7 @@ describe('registry : domain : repository', function(){
           'errors-component',
           'handlebars3-component',
           'hello-world',
+          'hello-world-custom-headers',
           'language',
           'no-containers',
           'underscore-component',

--- a/test/unit/registry-domain-validator.js
+++ b/test/unit/registry-domain-validator.js
@@ -289,6 +289,46 @@ describe('registry : domain : validator', function(){
         });
       });
     });
+
+    describe('customHeadersToSkipOnWeakVersion', function() {
+      describe('when customHeadersToSkipOnWeakVersion is not an array', function() {
+        var conf = { 
+          customHeadersToSkipOnWeakVersion: 'test', 
+          publishAuth: false, 
+          s3: baseS3Conf 
+        };
+
+        it('should not be valid', function() {
+          expect(validate(conf).isValid).to.be.false;
+          expect(validate(conf).message).to.equal('Registry configuration is not valid: customHeadersToSkipOnWeakVersion must be an array of strings');
+        });
+      });
+
+      describe('when customHeadersToSkipOnWeakVersion is an array but contains non-string elements', function() {
+        var conf = { 
+          customHeadersToSkipOnWeakVersion: ['header1', 'header2', 3, 4], 
+          publishAuth: false, 
+          s3: baseS3Conf
+        };
+
+        it('should not be valid', function() {
+          expect(validate(conf).isValid).to.be.false;
+          expect(validate(conf).message).to.equal('Registry configuration is not valid: customHeadersToSkipOnWeakVersion must be an array of strings');
+        });
+      });
+
+      describe('when customHeadersToSkipOnWeakVersion is a non-empty array of strings', function() {
+        var conf = { 
+          customHeadersToSkipOnWeakVersion: ['header1', 'header2', 'header3'],
+          publishAuth: false, 
+          s3: baseS3Conf
+        };
+
+        it('should be valid', function() {
+          expect(validate(conf).isValid).to.be.true;
+        });
+      });
+    });
   });
 
   describe('when validating component request by parameter', function(){

--- a/test/unit/registry-routes-component.js
+++ b/test/unit/registry-routes-component.js
@@ -465,7 +465,7 @@ describe('registry : routes : component', function(){
     });
   });
 
-  describe('when getting a component with server.js that sets custom headers with empty customHeadersToSkipOnWeakVersion', function() {
+  describe('when getting a component with server.js that sets custom headers with non-empty customHeadersToSkipOnWeakVersion', function() {
     var code, response, headers;
 
     before(function(done) {
@@ -500,9 +500,8 @@ describe('registry : routes : component', function(){
       expect(code).to.be.equal(200);
     });
 
-    it('should not set the HTTP response test-headers', function() {
-      expect(response.headers).to.not.be.null;      
-      expect(response.headers['test-header']).to.equal('test-value');
+    it('should not set response headers', function() {
+      expect(response.headers).to.be.undefined;
       expect(headers).to.be.undefined;      
     });
 

--- a/test/unit/registry-routes-component.js
+++ b/test/unit/registry-routes-component.js
@@ -418,7 +418,7 @@ describe('registry : routes : component', function(){
     });
   });
 
-  describe('when getting a component with server.js that sets custom headers', function() {
+  describe('when getting a component with server.js that sets custom headers with empty customHeadersToSkipOnWeakVersion', function() {
     var code, response, headers;
 
     before(function(done) {
@@ -457,6 +457,53 @@ describe('registry : routes : component', function(){
       expect(response.headers['test-header']).to.equal('test-value');
       expect(headers).to.not.be.null;      
       expect(headers['test-header']).to.equal('test-value');
+    });
+
+    it('should return component\'s name and request version', function() {
+      expect(response.name).to.equal('response-headers-component');
+      expect(response.requestVersion).to.equal('1.X.X');
+    });
+  });
+
+  describe('when getting a component with server.js that sets custom headers with empty customHeadersToSkipOnWeakVersion', function() {
+    var code, response, headers;
+
+    before(function(done) {
+      initialise(mockedComponents['response-headers-component']);
+      componentRoute = new ComponentRoute({}, mockedRepository);
+
+      var resJson = function(calledCode, calledResponse) {
+        code = calledCode;
+        response = calledResponse;
+        done();
+      };
+
+      var resSet = function(calledHeaders) {
+        headers = calledHeaders;
+      };
+
+      componentRoute({
+        headers: {},
+        params: { componentName: 'response-headers-component', componentVersion: '1.X.X' }
+      }, {
+        conf: {
+          baseUrl: 'http://component.com/',
+          executionTimeout: 0.1,
+          customHeadersToSkipOnWeakVersion: ['test-header']
+        },
+        json: resJson,
+        set: resSet
+      });
+    });
+
+    it('should return 200 status code', function() {
+      expect(code).to.be.equal(200);
+    });
+
+    it('should not set the HTTP response test-headers', function() {
+      expect(response.headers).to.not.be.null;      
+      expect(response.headers['test-header']).to.equal('test-value');
+      expect(headers).to.be.undefined;      
     });
 
     it('should return component\'s name and request version', function() {


### PR DESCRIPTION
- Introduced a new registry option - customHeadersToSkipOnWeakVersion, which expects
to be an array of strings denoting the headers to be omitted from
the response in case a weak version is requested (i.e 1.x.x). The rational
behind this is the need to control cache related headers - in case 1.x.x
version is requested we would not like cache headers to be returned because
otherwise the response will be cached. Next time when someone asks for 1.x.x
it will get the cached response even though a new version may be available.
- by default customHeadersToSkipOnWeakVersion  is set to be empty.
- added unit and integration tests.