### PR TITLE
removed define production on server bundle

### DIFF
--- a/src/cli/domain/package-server-script/bundle/config/index.js
+++ b/src/cli/domain/package-server-script/bundle/config/index.js
@@ -42,11 +42,6 @@ module.exports = function webpackConfigGenerator(params){
         }
       ]
     },
-    plugins: [
-      new webpack.DefinePlugin({
-        'process.env.NODE_ENV': JSON.stringify('production')
-      })
-    ],
     resolveLoader: {
       modules: ['node_modules', path.resolve(__dirname, '../../../../../../node_modules')]
     }


### PR DESCRIPTION
As reported by @tkant 

```
NODE_ENV=test oc dev . 3030
console.log(’NODE_ENV: ‘ + process.env.NODE_ENV);
Its throwing 'production'
```