### PR TITLE
Fix regex on win paths normalisation

### DIFF
--- a/src/registry/domain/s3.js
+++ b/src/registry/domain/s3.js
@@ -109,7 +109,7 @@ module.exports = function(conf){
 
         async.each(files, function(file, cb){
           var relativeFile = file.substr(dirInput.length),
-              url = (dirOutput + relativeFile).replace(/\\/, '/');
+              url = (dirOutput + relativeFile).replace(/\\/g, '/');
 
           self.putFile(file, url, relativeFile === '/server.js', cb);
         }, function(errors){

--- a/test/unit/registry-domain-s3.js
+++ b/test/unit/registry-domain-s3.js
@@ -76,7 +76,7 @@ describe('registry : domain : s3', function(){
   var initialiseAndExecutePutDir = function(callback){
     initialise();
     mockedS3Client.putObject.yields(null, 'ok');
-    s3.putDir('/absolute-path-to-dir', 'components/componentName/1.0.0', function(err, res){
+    s3.putDir('/absolute-path-to-dir', 'components\\componentName\\1.0.0', function(err, res){
       error = err;
       response = res;
       callback();


### PR DESCRIPTION
Fixes #386 

After doing some hacking, I found that on windows the path was normalised from `\\something\\something\\something` to `/something\something\something` instead of `/something/something/something`. Then I had a better look at the normalisation regex and spotted the issue.