### PR TITLE
Tweaking README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 ![oc](https://raw.githubusercontent.com/opentable/oc/master/logo.png)
 =============
 
-OpenComponents, **serverless in the front-end world**.
-
 OpenComponents is an open-source framework that allows fast-moving teams to easily build and deploy front-end components. It abstracts away complicated infrastructure and leaves developers with very simple, but powerful building blocks that handle scale transparently.
+
+Imagine something **as simple as an iframe, that is not an actual iframe**:
+```html
+<oc-component href="//oc-registry.com/hello/1.x.x?name=John"></oc-component>
+```
 
 #### How does it work?
 


### PR DESCRIPTION
1) I like serverless architectures, but I feel like it is half loved half hated. Also, most often refers to frameworks on top of lambda, and oc is not. So I think we should remove it.
2) A recurrent theme when we made the OC meetup was about iframes and how much of OC was inspired by iframes and how they should be in an ideal world.

What do you think about this little changes?