### PR TITLE
Fixing typo on registry UI for filtering.

### DIFF
--- a/src/registry/views/static/list-components.js
+++ b/src/registry/views/static/list-components.js
@@ -49,7 +49,7 @@ oc.cmd.push(function(){
   };
 
   $('#filter-components').submit(componentsListChanged).keyup(componentsListChanged);
-  $('#filter-components input[type=checkbox').change(componentsListChanged);
+  $('#filter-components input[type=checkbox]').change(componentsListChanged);
 
   if(!!q){
     $('.search').val(q);


### PR DESCRIPTION
Current the check boxes to hide deprecated and experimental components are broken on Safari due to a missing close bracket. This somehow works fine in Chrome.