### PR TITLE
Ensuring we exit the domains in case of timeout

### DIFF
--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -287,6 +287,7 @@ module.exports = function(conf, repository){
               returnComponent({
                 message: format('timeout ({0}ms)', conf.executionTimeout * 1000)
               });
+              domain.exit();
             }, conf.executionTimeout * 1000);
           }
         };


### PR DESCRIPTION
https://nodejs.org/dist/latest-v6.x/docs/api/domain.html#domain_domain_exit
This allows us to handle properly the scenario of timedout terminated component execution.