### PR TITLE
Fix ui preview with multiple discover strategies and endpoints

### DIFF
--- a/src/registry/routes/component-info.js
+++ b/src/registry/routes/component-info.js
@@ -58,7 +58,7 @@ function componentInfo(err, req, res, component) {
     return res.render('component-info', {
       component: component,
       dependencies: _.keys(component.dependencies),
-      href: res.conf.baseUrl,
+      href: '//' + req.headers.host + res.conf.prefix,
       parsedAuthor: parsedAuthor,
       sandBoxDefaultQs: urlBuilder.queryString(params)
     });


### PR DESCRIPTION
Fixes #369

More in details, here is the reproduction steps.
* We have 2 instances of the registry:
  * my-registry.mycorpintranet.com is a private instance with discovery: true (the UI is accessible)
  * my-registry.mycompany.com is a public instance with discovery: false
  * private instance has baseUrl configured to my-registry.mycompany.com (public) in order to allow client-side rendering failover/nested rendering

Currently, when accessing the private instance's UI on a component page, preview's Iframe URL is set to `~preview`, which works, but the URL on the preview bar is set on baseURL, which means hitting Refresh is gonna hit the public url with discovery: false, and the preview is not gonna be visible.

With this fix, we set the URL on the preview bar based on the current host, which means hitting Refresh is gonna hit the correct page with discovery: true.

I tested this locally by using some host entries and it works fine.
/cc @mattiaerre @chriscartlidge 