### PR TITLE
Transpile static js before minification

### DIFF
--- a/src/cli/domain/package-static-files.js
+++ b/src/cli/domain/package-static-files.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var async = require('async');
+var babel = require('babel-core');
+var babelPresetEnv = require('babel-preset-env');
 var CleanCss = require('clean-css');
 var format = require('stringformat');
 var fs = require('fs-extra');
@@ -14,7 +16,19 @@ var strings = require('../../resources');
 var minifyFile = function(fileType, fileContent, ocOptions){
 
   if(fileType === '.js'){
-    return uglifyJs.minify(fileContent, { fromString: true }).code;
+
+    var presetOptions = {
+      targets: {
+        browsers: 'not ie <= 8'
+      }
+    };
+
+    var babelOptions = {
+      presets: [[babelPresetEnv, babelOptions]]
+    };
+
+    var es5 = babel.transform(fileContent, babelOptions).code;
+    return uglifyJs.minify(es5, { fromString: true }).code;
   } else if(fileType === '.css'){
     return new CleanCss().minify(fileContent).styles;
   }

--- a/src/cli/domain/package-static-files.js
+++ b/src/cli/domain/package-static-files.js
@@ -24,7 +24,7 @@ var minifyFile = function(fileType, fileContent, ocOptions){
     };
 
     var babelOptions = {
-      presets: [[babelPresetEnv, babelOptions]]
+      presets: [[babelPresetEnv, presetOptions]]
     };
 
     var es5 = babel.transform(fileContent, babelOptions).code;

--- a/test/unit/cli-domain-package-static-files.js
+++ b/test/unit/cli-domain-package-static-files.js
@@ -21,6 +21,11 @@ var initialise = function(mocks, params, cb){
 var cleanup = function(){
   error = null;
   mocks = {
+    'babel-core': {
+      transform: sinon.stub().returns({
+        code: 'this-is-transpiled'
+      })
+    },
     'clean-css': sinon.stub().returns({
       minify: function(){
         return { styles: 'this-is-minified'};
@@ -53,9 +58,11 @@ var cleanup = function(){
         return _.toArray(arguments).join('/');
       }
     },
-    'uglify-js': { minify: sinon.stub().returns({
-      code: 'this-is-minified'
-    })}
+    'uglify-js': {
+      minify: sinon.stub().returns({
+        code: 'this-is-minified'
+      })
+    }
   };
 };
 
@@ -242,8 +249,9 @@ describe('cli : domain : packageStaticFiles', function(){
           expect(error).to.be.null;
         });
 
-        it('should first minify the file', function(){
+        it('should first transpile and minify the file', function(){
           expect(mocks['fs-extra'].readFileSync.calledOnce).to.be.true;
+          expect(mocks['babel-core'].transform.calledOnce).to.be.true;
           expect(mocks['uglify-js'].minify.calledOnce).to.be.true;
         });
 


### PR DESCRIPTION
Fixes #409 

Quick note, I think we discussed about using babili, but after having a chat with @nickbalestra and making a test, I decided to still use uglify, but with babel on top.

With a test I made (using moment.js), babel+uglify => ~30KB VS babel+babili => ~45KB - so it turns out es5 + uglify is still more effective. We obviously may revisit in the future if makes sense.