### PR TITLE
[GPT-517] Exposing registry supported templates via context

### DIFF
--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -167,7 +167,8 @@ module.exports = function(dependencies){
             port: port,
             baseUrl: baseUrl,
             env: { name: 'local' },
-            dependencies: dependencies
+            dependencies: dependencies,
+            templates: ['oc-template-handlebars', 'oc-template-jade']
           });
 
           registerPlugins(registry);

--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -168,7 +168,7 @@ module.exports = function(dependencies){
             baseUrl: baseUrl,
             env: { name: 'local' },
             dependencies: dependencies,
-            templates: ['oc-template-handlebars', 'oc-template-jade']
+            templates: []
           });
 
           registerPlugins(registry);

--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -175,6 +175,16 @@ module.exports = function(conf){
     getStaticFilePath: function(componentName, componentVersion, filePath){
       return this.getComponentPath(componentName, componentVersion) + (conf.local ? settings.registry.localStaticRedirectorPath : '') + filePath;
     },
+    getTemplates: function(){
+      return conf.templates.map(function(template){
+        var info = require(template).getInfo();
+        return {
+          type: info.type,
+          version: info.version,
+          externals: info.externals
+        }
+      });
+    },
     init: function(callback){
       if(conf.local){
         return callback(null, 'ok');

--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -176,14 +176,17 @@ module.exports = function(conf){
       return this.getComponentPath(componentName, componentVersion) + (conf.local ? settings.registry.localStaticRedirectorPath : '') + filePath;
     },
     getTemplates: function(){
-      return conf.templates.map(function(template){
-        var info = require(template).getInfo();
-        return {
-          type: info.type,
-          version: info.version,
-          externals: info.externals
-        }
-      });
+      if (conf.templates) {
+        return conf.templates.map(function(template){
+          var info = require(template).getInfo();
+          return {
+            type: info.type,
+            version: info.version,
+            externals: info.externals
+          };
+        });
+      }
+      return [];
     },
     init: function(callback){
       if(conf.local){

--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -22,6 +22,22 @@ module.exports = function(conf){
   var getFilePath = function(component, version, filePath){
     return format('{0}/{1}/{2}/{3}', conf.s3.componentsDir, component, version, filePath);
   };
+
+  var coreTemplates = ['oc-template-jade', 'oc-template-handlebars'];
+  var templates = _.union(coreTemplates, conf.templates)
+    .map(function(template){
+      var info;
+      try {
+        info = require(template).getInfo();
+      } catch (err) {
+        throw new Error(format(strings.errors.registry.TEMPLATE_NOT_FOUND, template));
+      }
+      return {
+        type: info.type,
+        version: info.version,
+        externals: info.externals
+      };
+    });
   
   var local = {
     getCompiledView: function(componentName, componentVersion){
@@ -64,6 +80,7 @@ module.exports = function(conf){
       return fs.readFileSync(path.join(conf.path, componentName + '/_package/server.js')).toString();
     }
   };
+  
 
   return {
     getCompiledView: function(componentName, componentVersion, callback){
@@ -176,17 +193,7 @@ module.exports = function(conf){
       return this.getComponentPath(componentName, componentVersion) + (conf.local ? settings.registry.localStaticRedirectorPath : '') + filePath;
     },
     getTemplates: function(){
-      if (conf.templates) {
-        return conf.templates.map(function(template){
-          var info = require(template).getInfo();
-          return {
-            type: info.type,
-            version: info.version,
-            externals: info.externals
-          };
-        });
-      }
-      return [];
+      return templates;
     },
     init: function(callback){
       if(conf.local){

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -269,7 +269,8 @@ module.exports = function(conf, repository){
                   responseHeaders = responseHeaders || {};
                   responseHeaders[header.toLowerCase()] = value;
                 }
-              }
+              },
+              templates: repository.getTemplates()
             };
 
         var setCallbackTimeout = function(){

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -58,7 +58,8 @@ module.exports = {
       PLUGIN_NOT_FOUND: 'Component is trying to use un-registered plugins: {0}',
       PLUGIN_NOT_IMPLEMENTED: 'registry does not implement plugins: {0}',
       PLUGIN_NOT_VALID: 'Plugin {0} is not valid',
-      RESOLVING_ERROR: 'component resolving error'
+      RESOLVING_ERROR: 'component resolving error',
+      TEMPLATE_NOT_FOUND: 'Template {0} not found'
     },
     cli: {
       COMPONENT_HREF_NOT_FOUND: 'The specified path is not a valid component\'s url',

--- a/test/unit/registry-domain-repository.js
+++ b/test/unit/registry-domain-repository.js
@@ -90,6 +90,42 @@ describe('registry : domain : repository', function(){
       });
     });
 
+    describe('when getting the list of supported templates', function(){
+      describe('when no templates are specificed on the configuaration', function(){
+        it('should return core templates', function(){
+          expect(repository.getTemplates().length).to.equal(2);
+          expect(repository.getTemplates()[0].type).to.equal('oc-template-jade');
+          expect(repository.getTemplates()[1].type).to.equal('oc-template-handlebars');
+        });
+      });
+
+      describe('when the templates specificed on the configuaration are core-templates', function(){
+        it('should only return uniques templates', function(){
+           var conf = _.extend(
+            cdnConfiguration,
+            {templates: ['oc-template-jade']}
+          );
+          var repository = new Repository(conf);
+          expect(repository.getTemplates().length).to.equal(2);  
+        });
+      });
+
+      describe('when templates specificed on the configuaration are not installed', function(){
+        it('should throw an error', function(){
+          var conf = _.extend(
+            cdnConfiguration,
+            {templates: ['oc-template-react']}
+          );
+
+          try {
+            var repository = new Repository(conf);
+          } catch (err) {
+            expect(err).to.deep.equal(new Error('Template oc-template-react not found'));  
+          }
+        });
+      });
+    });
+
     describe('when trying to get a not valid component', function(){
 
       describe('when the component does not exist', function(){

--- a/test/unit/registry-routes-component.js
+++ b/test/unit/registry-routes-component.js
@@ -18,6 +18,7 @@ describe('registry : routes : component', function(){
       getCompiledView: sinon.stub().yields(null, params.view),
       getComponent: sinon.stub().yields(null, params.package),
       getDataProvider: sinon.stub().yields(null, params.data),
+      getTemplates: sinon.stub(),
       getStaticFilePath: sinon.stub().returns('//my-cdn.com/files/')
     };
   };
@@ -508,6 +509,7 @@ describe('registry : routes : component', function(){
         getCompiledView: sinon.stub(),
         getComponent: sinon.stub(),
         getDataProvider: sinon.stub(),
+        getTemplates: sinon.stub(),
         getStaticFilePath: sinon.stub().returns('//my-cdn.com/files/')
       };
 

--- a/test/unit/registry-routes-components.js
+++ b/test/unit/registry-routes-components.js
@@ -18,6 +18,7 @@ describe('registry : routes : components', function(){
       getCompiledView: sinon.stub().yields(null, params.view),
       getComponent: sinon.stub().yields(null, params.package),
       getDataProvider: sinon.stub().yields(null, params.data),
+      getTemplates: sinon.stub(),
       getStaticFilePath: sinon.stub().returns('//my-cdn.com/files/')
     };
   };

--- a/test/unit/registry-routes-helpers-get-component.js
+++ b/test/unit/registry-routes-helpers-get-component.js
@@ -23,6 +23,7 @@ describe('registry : routes : helpers : get-component', function(){
       getCompiledView: sinon.stub().yields(null, params.view),
       getComponent: sinon.stub().yields(null, params.package),
       getDataProvider: sinon.stub().yields(null, params.data),
+      getTemplates: sinon.stub(),
       getStaticFilePath: sinon.stub().returns('//my-cdn.com/files/')
     };
   };


### PR DESCRIPTION
- [x]  CLi dev configure with `oc-template-jade` and `oc-template-handlebars` by default
- [x] `getTemplate()` helper for the repository to leverage on template.getInfo() API
- [x] add templates to contextObj

@matteofigus did I miss anything? (Still WIP)