### PR TITLE
[GPT-518] dynamically register templates on browser client

### DIFF
--- a/src/components/oc-client/server.js
+++ b/src/components/oc-client/server.js
@@ -1,5 +1,6 @@
 'use strict';
 
-module.exports.data = function(context, callback){
-  callback(null, { staticPath: context.staticPath });
+export const data = (context, callback) => {
+  const { staticPath, templates } = context;
+  return callback(null, { staticPath, templates });
 };

--- a/src/components/oc-client/template.jade
+++ b/src/components/oc-client/template.jade
@@ -1,15 +1,3 @@
 script(src=staticPath+"src/oc-client.min.js", type="text/javascript")
 script.
-  oc.registerTemplates({
-    type: 'oc-template-react',
-    externals: [
-      {
-        "global": "React",
-        "url": "https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react.min.js"
-      },
-      {
-        "global": "ReactDOM",
-        "url": "https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react-dom.min.js"
-      }
-    ]
-  });
+  oc.registerTemplates(!{JSON.stringify(templates)});

--- a/src/components/oc-client/template.jade
+++ b/src/components/oc-client/template.jade
@@ -1,3 +1,6 @@
-script(src=staticPath+"src/oc-client.min.js", type="text/javascript")
 script.
-  oc.registerTemplates(!{JSON.stringify(templates)});
+  window.oc = window.oc || {};
+  oc.conf = oc.conf || {};
+  oc.conf.templates = oc.conf.templates || [];
+  oc.conf.templates = oc.conf.templates.concat(!{JSON.stringify(templates)});
+script(src=staticPath+"src/oc-client.min.js", type="text/javascript")

--- a/src/components/oc-client/template.jade
+++ b/src/components/oc-client/template.jade
@@ -1,1 +1,15 @@
 script(src=staticPath+"src/oc-client.min.js", type="text/javascript")
+script.
+  oc.registerTemplates({
+    type: 'oc-template-react',
+    externals: [
+      {
+        "global": "React",
+        "url": "https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react.min.js"
+      },
+      {
+        "global": "ReactDOM",
+        "url": "https://cdnjs.cloudflare.com/ajax/libs/react/15.4.2/react-dom.min.js"
+      }
+    ]
+  });


### PR DESCRIPTION
Now that we have registry supported [templates exposed in context](https://github.com/opentable/oc/pull/423). We could imagine to use this to programmatically and dynamically configure the browser client to support them [via the registerTemplate API](https://github.com/opentable/oc/pull/396).

- [x] extend browser oc-client component to use registerTemplate APIs.
- [x] dependency on #428
- [x] dependency on #426 