### PR TITLE
[GPT-567] Registering supported templates on componentPreview view

### DIFF
--- a/src/registry/routes/component-preview.js
+++ b/src/registry/routes/component-preview.js
@@ -5,7 +5,7 @@ var _ = require('underscore');
 var urlBuilder = require('../domain/url-builder');
 var getComponentFallback = require('./helpers/get-component-fallback');
 
-function componentPreview(err, req, res, component) {
+function componentPreview(err, req, res, component, templates) {
     if(err) {
         res.errorDetails = err.registryError || err;
         res.errorCode = 'NOT_FOUND';
@@ -20,7 +20,8 @@ function componentPreview(err, req, res, component) {
             component: component,
             dependencies: _.keys(component.dependencies),
             href: res.conf.baseUrl,
-            qs: urlBuilder.queryString(req.query)
+            qs: urlBuilder.queryString(req.query),
+            templates: templates
         });
 
     } else {
@@ -37,11 +38,11 @@ module.exports = function(conf, repository){
 
       if(registryError && conf.fallbackRegistryUrl) {
         return getComponentFallback.getComponentPreview(conf, req, res, registryError, function(fallbackError, fallbackComponent){
-            componentPreview(fallbackError, req, res, fallbackComponent);
+            componentPreview(fallbackError, req, res, fallbackComponent, repository.getTemplates());
         });
       }
 
-      componentPreview(registryError, req, res, component);
+      componentPreview(registryError, req, res, component, repository.getTemplates());
 
     });
   };

--- a/src/registry/views/component-preview.jade
+++ b/src/registry/views/component-preview.jade
@@ -5,6 +5,9 @@ html
   body
     - var baseUrl = href.replace('http\:\/\/', '\/\/').replace('https\:\/\/', '\/\/');
     oc-component(href=baseUrl+component.name+'/'+component.version+'/'+qs)
-    script(src=baseUrl+'oc-client/client.js')
     script.
-      oc.registerTemplates(!{JSON.stringify(templates)});
+      window.oc = window.oc || {};
+      oc.conf = oc.conf || {};
+      oc.conf.templates = oc.conf.templates || [];
+      oc.conf.templates = oc.conf.templates.concat(!{JSON.stringify(templates)});
+    script(src=baseUrl+'oc-client/client.js')

--- a/src/registry/views/component-preview.jade
+++ b/src/registry/views/component-preview.jade
@@ -6,3 +6,5 @@ html
     - var baseUrl = href.replace('http\:\/\/', '\/\/').replace('https\:\/\/', '\/\/');
     oc-component(href=baseUrl+component.name+'/'+component.version+'/'+qs)
     script(src=baseUrl+'oc-client/client.js')
+    script.
+      oc.registerTemplates(!{JSON.stringify(templates)});


### PR DESCRIPTION
Rely on `repository.getTemplates()` to register supported templates for client-rendering on the componentPreview view.

[Info on repository.getTemplates()](https://github.com/opentable/oc/pull/423)