### PR TITLE
Require templates is broken

### DIFF
--- a/client/src/utils/require-template.js
+++ b/client/src/utils/require-template.js
@@ -21,10 +21,9 @@ function isValidTemplate(template){
   });
 }
 
-
 module.exports = function(template) {
   var ocTemplate;
-  var localTemplate = path.join(__dirname, '../../', 'node_modules', template);
+  var localTemplate = path.join(__dirname, '../../../', 'node_modules', template);
   var relativeTemplate = path.resolve('.', 'node_modules', template);
   
   try {

--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -38,10 +38,6 @@ module.exports = function(conf){
       } catch (err) {
         throw err;
       }
-      
-      
-
-      
     });
   
   var local = {


### PR DESCRIPTION
@nickbalestra I believe this was introduced in one of the recent PRs.

```js
{
  code: "INTERNAL_SERVER_ERROR",
  error: "Error requiring oc-template: "oc-template-jade" not found",
  name: "xxxxx",
  requestVersion: "xxxxx"
}
```
Actions:
1) I noticed that the repository calls the require-template (which has expensive stuff like the deletes and the require stuff with the cache invalidation) on each component execution. I think the deal was to do it only on registry start - so we may need to double check that
2) How was this not catched by any test? We need to definitely improve testing before releasing the next version (all the latest PRs about templating are un-released)