### PR TITLE
Consider null a valid string

### DIFF
--- a/src/registry/domain/sanitiser.js
+++ b/src/registry/domain/sanitiser.js
@@ -17,14 +17,11 @@ var sanitise = {
   numberParameter: function(variable){
     return variable*1;
   },
+  stringParameter: function(variable){
+    return _.isNull(variable) ? '' : variable;
+  },
   parameter: function(variable, type){
-    if(type === 'boolean'){
-      return sanitise.booleanParameter(variable);
-    } else if(type === 'number'){
-      return sanitise.numberParameter(variable);
-    }
-
-    return variable;
+    return sanitise[type + 'Parameter'](variable);
   }
 };
 

--- a/src/registry/domain/sanitiser.js
+++ b/src/registry/domain/sanitiser.js
@@ -21,7 +21,15 @@ var sanitise = {
     return _.isNull(variable) ? '' : variable;
   },
   parameter: function(variable, type){
-    return sanitise[type + 'Parameter'](variable);
+    if(type === 'boolean'){
+      return sanitise.booleanParameter(variable);
+    } else if(type === 'number'){
+      return sanitise.numberParameter(variable);
+    } else if(type === 'string'){
+      return sanitise.stringParameter(variable);
+    }
+
+    return variable;
   }
 };
 

--- a/src/registry/routes/helpers/apply-default-values.js
+++ b/src/registry/routes/helpers/apply-default-values.js
@@ -8,7 +8,8 @@ module.exports = function(requestParameters, expectedParameters) {
   });
   
   _.forEach(optionalParametersWithDefaults, function(expectedParameter, expectedParameterName){
-    if(!_.has(requestParameters, expectedParameterName)) {
+  	var param = requestParameters[expectedParameterName];
+    if(_.isUndefined(param) || _.isNull(param)) {
       requestParameters[expectedParameterName] = expectedParameter.default;
     }
   });

--- a/test/acceptance/registry.js
+++ b/test/acceptance/registry.js
@@ -765,7 +765,8 @@ describe('registry', function(){
               body: {
                 parameters: { firstName: 'John' },
                 components: [
-                  {name:'welcome-with-optional-parameters', parameters: { lastName: 'Smith', nick: 'smithy'}},
+                  {name:'welcome-with-optional-parameters', parameters: { lastName: 'Smith', nick: 'smithy' }},
+                  {name:'welcome-with-optional-parameters', parameters: { lastName: 'Smith', nick: null }},
                   {name:'welcome-with-optional-parameters', parameters: { lastName: 'Smith'}},
                   {name:'welcome-with-optional-parameters', parameters: { nick: 'smithy'}}
                 ]
@@ -778,14 +779,16 @@ describe('registry', function(){
             expect(result[0].response.href).to.equal('http://localhost:3030/welcome-with-optional-parameters?firstName=John&lastName=Smith&nick=smithy');
           });
 
-          it('should render second component with default value of nick', function(){
+          it('should render second and third components with default value of nick', function(){
             expect(result[1].response.html).to.equal('<span>hi John Smith (Johnny)</span>');
             expect(result[1].response.href).to.equal('http://localhost:3030/welcome-with-optional-parameters?firstName=John&lastName=Smith&nick=Johnny');
+            expect(result[2].response.html).to.equal('<span>hi John Smith (Johnny)</span>');
+            expect(result[2].response.href).to.equal('http://localhost:3030/welcome-with-optional-parameters?firstName=John&lastName=Smith&nick=Johnny');
           });
 
-          it('should render third component without value of lastName', function(){
-            expect(result[2].response.html).to.equal('<span>hi John  (smithy)</span>');
-            expect(result[2].response.href).to.equal('http://localhost:3030/welcome-with-optional-parameters?firstName=John&nick=smithy');
+          it('should render fourth component without value of lastName', function(){
+            expect(result[3].response.html).to.equal('<span>hi John  (smithy)</span>');
+            expect(result[3].response.href).to.equal('http://localhost:3030/welcome-with-optional-parameters?firstName=John&nick=smithy');
           });
         });
       });

--- a/test/unit/registry-domain-sanitiser.js
+++ b/test/unit/registry-domain-sanitiser.js
@@ -10,7 +10,7 @@ describe('registry : domain : sanitiser', function(){
 
     var sanitise = function(a,b){ return sanitiser.sanitiseComponentParameters(a,b); };
 
-    describe('when component have boolean parameter', function(){
+    describe('when component has boolean parameter', function(){
 
       it('should convert string to boolean when true', function(){
         
@@ -43,10 +43,28 @@ describe('registry : domain : sanitiser', function(){
 
         expect(sanitisedParameters).to.eql({ isTrue: false });
       });
-
     });
 
-    describe('when component have number parameter', function(){
+    describe('when component has string parameter', function(){
+
+      it('should convert null to empty', function(){
+
+        var componentParameters = {
+          myString: {
+            type: 'string',
+            mandatory: false,
+            example: 'hello'
+          }
+        };
+
+        var requestParameters = { myString: null },
+            sanitisedParameters = sanitise(requestParameters, componentParameters);
+
+        expect(sanitisedParameters).to.eql({ myString: '' });
+      });
+    });
+
+    describe('when component has number parameter', function(){
 
       it('should convert string to number', function(){
 

--- a/test/unit/registry-routes-helpers-apply-default-values.js
+++ b/test/unit/registry-routes-helpers-apply-default-values.js
@@ -98,13 +98,27 @@ describe('registry : routes : helpers : apply-default-values', function(){
       });
 
       describe('when request doesn\'t specify values of optional parameters', function(){
-        before(function(){
-          parameters = apply({ mandatory: 'request value' }, componentParameters);
+
+        describe('when string parameter is undefined', function(){
+          before(function(){
+            parameters = apply({ mandatory: 'request value' }, componentParameters);
+          });
+
+          it('should return requestParameters with default values of optional parameters', function(){
+            expect(parameters).to.eql({ mandatory: 'request value', optional: 'default value of optional parameter', optional2: false
+           });
+          });
         });
 
-        it('should return requestParameters with default values of optional parameters', function(){
-          expect(parameters).to.eql({ mandatory: 'request value', optional: 'default value of optional parameter', optional2: false
-         });
+        describe('when string parameter is null', function(){
+          before(function(){
+            parameters = apply({ mandatory: 'request value', optional: null }, componentParameters);
+          });
+
+          it('should return requestParameters with default values of optional parameters', function(){
+            expect(parameters).to.eql({ mandatory: 'request value', optional: 'default value of optional parameter', optional2: false
+           });
+          });
         });
       });
     });


### PR DESCRIPTION
Fixes #425 

I decided to proceed in the following way:
1) When a string null parameter gets sent to the request, it gets first parsed for applying default values. Before, it used to apply a default in case of undefined => now it applies default in case of null too.
2) After applying the default values, if any, there is a sanitisation process. If the string param is still null I sanitise it by converting it to empty string
3) Validation will be ok in case of empty.

I included some unit tests and also an acceptance that tests that too. 