### PR TITLE
Log error before exiting

### DIFF
--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -177,8 +177,8 @@ module.exports = function(dependencies){
               if(err.code === 'EADDRINUSE'){
                 err = format(strings.errors.cli.PORT_IS_BUSY, port);
               }
-              callback(err);
-              return log.err(err);
+              log.err(err);
+              return callback(err);
             }
 
             watchForChanges(components, packageComponents);


### PR DESCRIPTION
As reported by @pbazydlo 

FYI, callback then does a synchronous process.exit(1): https://github.com/opentable/oc/blob/master/src/cli/wrap-cli-callback.js#L12