### PR TITLE
Fix manual build script

### DIFF
--- a/tasks/version.js
+++ b/tasks/version.js
@@ -18,8 +18,8 @@ module.exports = function(grunt){
     fs.writeJsonSync(path.join(__dirname, '../package.json'), packageJson, {spaces: 2});
 
     grunt.task.run([
-      'test-local-silent',
       'build',
+      'test-local-silent',
       'git-stage'
     ]);
   });


### PR DESCRIPTION
New acceptance tests need the version to be consistent in order for the UI to start without errors. It follows that build script needs to run before all the tests to run. This is also cleaner.