### PR TITLE
[WIP] issue-with-component-info-get-params

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "stringformat": "0.0.5",
     "targz": "1.0.1",
     "uglify-js": "2.6.4",
+    "underscore": "^1.8.3",
     "watch": "0.19.1",
     "webpack": "2.2.0",
     "yargs": "^6.6.0"

--- a/src/registry/routes/helpers/get-params.js
+++ b/src/registry/routes/helpers/get-params.js
@@ -29,7 +29,7 @@ function getParams__(component) {
   return params;
 }
 
-const getParamsV2 = (component) => {
+function getParamsV2(component) {
   const params = {};
   if (component.oc.parameters) {
     Object.keys(component.oc.parameters).forEach((key) => {
@@ -39,6 +39,6 @@ const getParamsV2 = (component) => {
     });
   }
   return params;
-};
+}
 
 module.exports = { getParams__, getParams, getParamsV2 };

--- a/src/registry/routes/helpers/get-params.js
+++ b/src/registry/routes/helpers/get-params.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const _ = require('lodash');
 const __ = require('underscore');
 

--- a/src/registry/routes/helpers/get-params.js
+++ b/src/registry/routes/helpers/get-params.js
@@ -1,0 +1,44 @@
+const _ = require('lodash');
+const __ = require('underscore');
+
+function getParams(component) {
+  let params = {};
+  if (component.oc.parameters) {
+    const mandatoryParams = _.filter(_.keys(component.oc.parameters), (paramName) => {
+      const param = component.oc.parameters[paramName];
+      return !!param.mandatory && !!param.example;
+    });
+
+    params = _.mapValues(_.pickBy(component.oc.parameters, mandatoryParams), x => x.example);
+  }
+
+  return params;
+}
+
+function getParams__(component) {
+  let params = {};
+  if (component.oc.parameters) {
+    const mandatoryParams = __.filter(__.keys(component.oc.parameters), (paramName) => {
+      const param = component.oc.parameters[paramName];
+      return !!param.mandatory && !!param.example;
+    });
+
+    params = __.mapObject(__.pick(component.oc.parameters, mandatoryParams), (param) => param.example);
+  }
+
+  return params;
+}
+
+const getParamsV2 = (component) => {
+  const params = {};
+  if (component.oc.parameters) {
+    Object.keys(component.oc.parameters).forEach((key) => {
+      if (component.oc.parameters[key].mandatory) {
+        params[key] = component.oc.parameters[key].example;
+      }
+    });
+  }
+  return params;
+};
+
+module.exports = { getParams__, getParams, getParamsV2 };

--- a/src/registry/routes/helpers/get-params.js
+++ b/src/registry/routes/helpers/get-params.js
@@ -9,7 +9,7 @@ function getParams(component) {
       return !!param.mandatory && !!param.example;
     });
 
-    params = _.mapValues(_.pickBy(component.oc.parameters, mandatoryParams), x => x.example);
+    params = _.mapValues(_.pick(component.oc.parameters, mandatoryParams), x => x.example);
   }
 
   return params;

--- a/test/unit/registry-routes-helpers-get-params.js
+++ b/test/unit/registry-routes-helpers-get-params.js
@@ -1,0 +1,64 @@
+const expect = require('chai').expect;
+const { getParams, getParams__, getParamsV2 } = require('../../src/registry/routes/helpers/get-params.js');
+
+const scenarios = [
+  {
+    description: 'oc-apod',
+    parameters: {
+      apiKey:
+      {
+        type: 'string',
+        mandatory: true,
+        example: 'DEMO_KEY',
+        description: 'The NASA Open APIs key'
+      }
+    }
+  },
+  {
+    description: 'oc-columbus-header',
+    parameters: {
+      title:
+      {
+        type: 'string',
+        mandatory: true,
+        example: 'Instagram',
+        description: 'The main title'
+      },
+      logoUrl:
+      {
+        type: 'string',
+        mandatory: true,
+        example: 'http://www.uidownload.com/files/722/15/621/facebook-instagram-instagram-2016-instagram-logo-new-new-instagram-icon.png',
+        description: 'The logo\'s absolute url'
+      }
+    }
+  }
+];
+
+scenarios.forEach((scenario) => {
+  describe(scenario.description, () => {
+    it('getParams__ should match getParamsV2', () => {
+      const component = {
+        oc: {
+          parameters: scenario.parameters
+        }
+      };
+
+      expect(getParams__(component)).to.deep.equal(getParamsV2(component));
+    });
+  });
+});
+
+scenarios.forEach((scenario) => {
+  describe(scenario.description, () => {
+    it('getParams should match getParamsV2', () => {
+      const component = {
+        oc: {
+          parameters: scenario.parameters
+        }
+      };
+
+      expect(getParams(component)).to.deep.equal(getParamsV2(component));
+    });
+  });
+});

--- a/test/unit/registry-routes-helpers-get-params.js
+++ b/test/unit/registry-routes-helpers-get-params.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const { getParams, getParams__, getParamsV2 } = require('../../src/registry/routes/helpers/get-params.js');
+const helper = require('../../src/registry/routes/helpers/get-params.js');
 
 const scenarios = [
   {
@@ -44,7 +44,7 @@ scenarios.forEach((scenario) => {
         }
       };
 
-      expect(getParams__(component)).to.deep.equal(getParamsV2(component));
+      expect(helper.getParams__(component)).to.deep.equal(helper.getParamsV2(component));
     });
   });
 });
@@ -58,7 +58,7 @@ scenarios.forEach((scenario) => {
         }
       };
 
-      expect(getParams(component)).to.deep.equal(getParamsV2(component));
+      expect(helper.getParams(component)).to.deep.equal(helper.getParamsV2(component));
     });
   });
 });


### PR DESCRIPTION
# Description

as per #470 this PR adds a helper that can be used by `/src/registry/routes/component-info.js` in order to return the component's mandatory parameters as a map.

the integration hasn't been done yet as this PR only highlights the existing bug and compares:

1. `getParams` w/ `lodash` (aka `getParams`)

2. `getParams` w/ `underscode` (aka `getParams__`)

3. `getParams` w/o any dependencies (aka `getParamsV2`)

where

**1** has a bug, **2** and **3** behave the same

## Tests

<img width="1172" alt="screen shot 2017-04-22 at 18 05 34" src="https://cloud.githubusercontent.com/assets/6423261/25309639/30c53c7c-2787-11e7-9db3-c021f3bf0f87.png">
