### PR TITLE
[GPT-645] Handling data-provider compilation within template

### DIFF
--- a/client/src/get-compiled-template.js
+++ b/client/src/get-compiled-template.js
@@ -25,10 +25,7 @@ module.exports = function(cache){
           });
         }
 
-        let type = template.type;
-        if (type === 'jade') { type = 'oc-template-jade'; }
-        if (type === 'handlebars') { type = 'oc-template-handlebars'; }
-
+        const type = template.type;
         let ocTemplate;
         try {
           ocTemplate = requireTemplate(type);

--- a/client/src/template-renderer.js
+++ b/client/src/template-renderer.js
@@ -6,10 +6,7 @@ const requireTemplate = require('./utils/require-template');
 module.exports = function(){
   return function(template, model, options, callback){
 
-    let type = options.templateType;
-    if (type === 'jade') { type = 'oc-template-jade'; }
-    if (type === 'handlebars') { type = 'oc-template-handlebars'; }
-
+    const type = options.templateType;
     let ocTemplate;
     try {
       ocTemplate = requireTemplate(type);

--- a/client/src/utils/require-template.js
+++ b/client/src/utils/require-template.js
@@ -21,6 +21,9 @@ function isValidTemplate(template){
 
 module.exports = function(template) {
   let ocTemplate;
+  if (template === 'jade') { template = 'oc-template-jade'; }
+  if (template === 'handlebars') { template = 'oc-template-handlebars'; }
+
   const localTemplate = path.join(__dirname, '../../../', 'node_modules', template);
   const relativeTemplate = path.resolve('.', 'node_modules', template);
 

--- a/src/cli/domain/package-components.js
+++ b/src/cli/domain/package-components.js
@@ -98,7 +98,7 @@ module.exports = function(){
             delete component.oc.files.data;
             return cb(err, component);
           });
-        }); 
+        });
       },
       function(component, cb){
         // Packaging package.json

--- a/src/cli/domain/package-components.js
+++ b/src/cli/domain/package-components.js
@@ -10,6 +10,7 @@ const packageStaticFiles = require('./package-static-files');
 const packageTemplate = require('./package-template');
 const getUnixUtcTimestamp = require('../../utils/get-unix-utc-timestamp');
 const validator = require('../../registry/domain/validators');
+const requireTemplate = require('../../utils/require-template');
 
 module.exports = function(){
   return function(options, callback){
@@ -66,7 +67,18 @@ module.exports = function(){
           return cb(null, component);
         }
 
-        packageServerScript({
+        const type = component.oc.files.template.type;
+        let ocTemplate;
+
+        try {
+          ocTemplate = requireTemplate(type);
+        } catch (err) {
+          return cb(err);
+        }
+
+        const compileServer = ocTemplate.compileServer ? ocTemplate.compileServer : packageServerScript;
+
+        compileServer({
           componentPath: componentPath,
           dependencies: component.dependencies,
           ocOptions: component.oc,
@@ -78,8 +90,8 @@ module.exports = function(){
           component.oc.files.dataProvider = packagedServerScriptInfo;
           delete component.oc.files.data;
           cb(err, component);
-        });
-      },
+        }); 
+    },
       function(component, cb){
         // Packaging package.json
 

--- a/src/cli/domain/package-components.js
+++ b/src/cli/domain/package-components.js
@@ -77,13 +77,11 @@ module.exports = function(){
         }
 
         const compileServer = ocTemplate.compileServer ? ocTemplate.compileServer : packageServerScript;
-        const fileName = 'server.js';
 
         compileServer({
           componentPath: componentPath,
           dependencies: component.dependencies,
           ocOptions: component.oc,
-          fileName,
           verbose: options.verbose
         }, (err, bundledServer) => {
           if(err){ return cb(err); }

--- a/src/cli/domain/package-server-script/index.js
+++ b/src/cli/domain/package-server-script/index.js
@@ -10,7 +10,7 @@ module.exports = function packageServerScript(params, callback){
   const bundleParams = {
     webpack: params.webpack || webpackParams,
     dependencies: params.dependencies || {},
-    fileName: params.fileName,
+    fileName: params.ocOptions.files.data,
     dataPath: path.join(params.componentPath, params.ocOptions.files.data)
   };
 

--- a/src/cli/domain/package-server-script/index.js
+++ b/src/cli/domain/package-server-script/index.js
@@ -1,20 +1,16 @@
 'use strict';
 
-const fs = require('fs-extra');
 const path = require('path');
 
 const bundle = require('./bundle');
-const hashBuilder = require('../../../utils/hash-builder');
 
 module.exports = function packageServerScript(params, callback){
-  const fileName = 'server.js';
-  const publishPath = params.publishPath;
   const webpackParams = { stats: params.verbose ? 'verbose' : 'errors-only' };
 
   const bundleParams = {
     webpack: params.webpack || webpackParams,
     dependencies: params.dependencies || {},
-    fileName: fileName,
+    fileName: params.fileName,
     dataPath: path.join(params.componentPath, params.ocOptions.files.data)
   };
 
@@ -22,13 +18,7 @@ module.exports = function packageServerScript(params, callback){
     if (err) {
       return callback(err);
     } else {
-      fs.writeFile(path.join(publishPath, fileName), bundledServer, (err) => {
-        callback(err, {
-          type: 'node.js',
-          hashKey: hashBuilder.fromString(bundledServer),
-          src: fileName
-        });
-      });
+      return callback(null, bundledServer);
     }
   });
 };

--- a/src/cli/domain/package-template.js
+++ b/src/cli/domain/package-template.js
@@ -17,10 +17,6 @@ const compileView = function(viewPath, type, cb) {
   const template = fs.readFileSync(viewPath).toString();
   let ocTemplate;
 
-  if (type === 'jade') { type = 'oc-template-jade'; }
-  if (type === 'handlebars') { type = 'oc-template-handlebars'; }
-
-
   try {
     ocTemplate = requireTemplate(type);
   } catch (err) {

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -230,9 +230,7 @@ module.exports = function(conf, repository){
           } else {
             repository.getCompiledView(component.name, component.version, (err, templateText) => {
               let ocTemplate;
-              let type = component.oc.files.template.type;
-              if (type === 'jade') { type = 'oc-template-jade'; }
-              if (type === 'handlebars') { type = 'oc-template-handlebars'; }
+              const type = component.oc.files.template.type;
 
               try {
                 ocTemplate = requireTemplate(type);

--- a/src/utils/require-template.js
+++ b/src/utils/require-template.js
@@ -22,6 +22,9 @@ function isValidTemplate(template){
 
 module.exports = function(template) {
   let ocTemplate;
+  if (template === 'jade') { template = 'oc-template-jade'; }
+  if (template === 'handlebars') { template = 'oc-template-handlebars'; }
+
   const localTemplate = path.join(__dirname, '../../', 'node_modules', template);
   const relativeTemplate = path.resolve('.', 'node_modules', template);
 

--- a/test/integration/cli-domain-package-server-script/cli-domain-package-server-script.js
+++ b/test/integration/cli-domain-package-server-script/cli-domain-package-server-script.js
@@ -47,6 +47,7 @@ describe('cli : domain : package-server-script', () => {
         try {
           packageServerScript(
             {
+              fileName: serverName,
               componentPath: componentPath,
               ocOptions: {
                 files: {
@@ -80,9 +81,10 @@ describe('cli : domain : package-server-script', () => {
         done();
       });
 
-      it('should save compiled data provider and return a hash for the script', (done) => {
+      it('should return compiled data provider', (done) => {
         packageServerScript(
           {
+            fileName: serverName,
             componentPath: componentPath,
             ocOptions: {
               files: {
@@ -92,16 +94,12 @@ describe('cli : domain : package-server-script', () => {
             publishPath: publishPath,
             webpack: webpackOptions
           },
-          (err, res) => {
+          (err, bundle) => {
             if (err) {
               return done(err);
             }
             try {
-              expect(res.type).to.equal('node.js');
-              expect(res.src).to.equal('server.js');
-
-              const compiledContent = fs.readFileSync(path.resolve(publishPath, res.src), {encoding: 'utf8'});
-              expect(res.hashKey).to.equal(hashBuilder.fromString(compiledContent));
+              expect(hashBuilder.fromString(bundle)).to.equal("7785f4d30799791847dd04fef9c87f015aa52574");
               done();
             } catch(e) {
               done(e);
@@ -130,6 +128,7 @@ describe('cli : domain : package-server-script', () => {
       it('should save compiled data provider encapsulating json content', (done) => {
         packageServerScript(
           {
+            fileName: serverName,
             componentPath: componentPath,
             ocOptions: {
               files: {
@@ -139,17 +138,12 @@ describe('cli : domain : package-server-script', () => {
             publishPath: publishPath,
             webpack: webpackOptions
           },
-          (err, res) => {
+          (err, bundle) => {
             if (err) {
               return done(err);
             }
             try {
-              const name = user.first;
-              const bundle = require(path.resolve(publishPath, res.src));
-              expect(bundle.data()).to.be.equal(name);
-
-              const compiledContent = fs.readFileSync(path.resolve(publishPath, res.src), {encoding: 'utf8'});
-              expect(compiledContent).to.contain('John');
+              expect(bundle).to.contain('John');
               done();
             } catch(e) {
               done(e);
@@ -174,6 +168,7 @@ describe('cli : domain : package-server-script', () => {
 
         packageServerScript(
           {
+            fileName: serverName,
             componentPath: componentPath,
             ocOptions: {
               files: {
@@ -184,16 +179,12 @@ describe('cli : domain : package-server-script', () => {
             webpack: webpackOptions,
             dependencies: dependencies
           },
-          (err, res) => {
+          (err, bundle) => {
             if (err) {
               return done(err);
             }
             try {
-              expect(res.type).to.equal('node.js');
-              expect(res.src).to.equal('server.js');
-
-              const compiledContent = fs.readFileSync(path.resolve(publishPath, res.src), {encoding: 'utf8'});
-              expect(res.hashKey).to.equal(hashBuilder.fromString(compiledContent));
+              expect('2d3ff75a97e724e9834f89d22fb215f4939fc57a').to.equal(hashBuilder.fromString(bundle));
               done();
             } catch(e) {
               done(e);
@@ -208,6 +199,7 @@ describe('cli : domain : package-server-script', () => {
 
           packageServerScript(
             {
+              fileName: serverName,
               componentPath: componentPath,
               ocOptions: {
                 files: {
@@ -242,6 +234,7 @@ describe('cli : domain : package-server-script', () => {
 
           packageServerScript(
             {
+              fileName: serverName,
               componentPath: componentPath,
               ocOptions: {
                 files: {
@@ -280,6 +273,7 @@ describe('cli : domain : package-server-script', () => {
       it('should save compiled data provider encapsulating js module content', (done) => {
         packageServerScript(
           {
+            fileName: serverName,
             componentPath: componentPath,
             ocOptions: {
               files: {
@@ -289,14 +283,12 @@ describe('cli : domain : package-server-script', () => {
             publishPath: publishPath,
             webpack: webpackOptions
           },
-          (err, res) => {
+          (err, bundle) => {
             if (err) {
               return done(err);
             }
             try {
-              const name = 'John';
-              const bundle = require(path.resolve(publishPath, res.src));
-              expect(bundle.data()).to.be.equal(name);
+              expect(bundle).to.be.contains("first:\'John\',last:\'Doe\'");
               done();
             } catch(e) {
               done(e);
@@ -317,6 +309,7 @@ describe('cli : domain : package-server-script', () => {
       it('should transpile it to es2015 through Babel', (done) => {
         packageServerScript(
           {
+            fileName: serverName,
             componentPath: componentPath,
             ocOptions: {
               files: {
@@ -326,16 +319,15 @@ describe('cli : domain : package-server-script', () => {
             publishPath: publishPath,
             webpack: webpackOptions
           },
-          (err, res) => {
+          (err, bundle) => {
             if (err) {
               return done(err);
             }
             try {
-              const compiledContent = fs.readFileSync(path.resolve(publishPath, res.src), {encoding: 'utf8'});
-              expect(compiledContent).to.not.contain('=>');
-              expect(compiledContent).to.not.contain('const');
-              expect(compiledContent).to.contain('var');
-              expect(compiledContent).to.contain('function');
+              expect(bundle).to.not.contain('=>');
+              expect(bundle).to.not.contain('const');
+              expect(bundle).to.contain('var');
+              expect(bundle).to.contain('function');
               done();
             } catch(e) {
               done(e);
@@ -360,6 +352,7 @@ describe('cli : domain : package-server-script', () => {
       it('should wrap while/do/for;; loops with an iterator limit', (done) => {
         packageServerScript(
           {
+            fileName: serverName,
             componentPath: componentPath,
             ocOptions: {
               files: {
@@ -369,15 +362,14 @@ describe('cli : domain : package-server-script', () => {
             publishPath: publishPath,
             webpack: webpackOptions
           },
-          (err, res) => {
+          (err, bundle) => {
             if (err) {
               return done(err);
             }
             try {
-              const compiledContent = fs.readFileSync(path.resolve(publishPath, res.src), {encoding: 'utf8'});
-              expect(compiledContent).to.contain('for(var r,a,t,i=1e9;;){if(i<=0)throw new Error(\"loop exceeded maximum allowed iterations\");r=234,i--}');
-              expect(compiledContent).to.contain('for(var i=1e9;;){if(i<=0)throw new Error(\"loop exceeded maximum allowed iterations\");a=546,i--}');
-              expect(compiledContent).to.contain('for(var i=1e9;;){if(i<=0)throw new Error(\"loop exceeded maximum allowed iterations\");t=342,i--}');
+              expect(bundle).to.contain('for(var r,a,t,i=1e9;;){if(i<=0)throw new Error(\"loop exceeded maximum allowed iterations\");r=234,i--}');
+              expect(bundle).to.contain('for(var i=1e9;;){if(i<=0)throw new Error(\"loop exceeded maximum allowed iterations\");a=546,i--}');
+              expect(bundle).to.contain('for(var i=1e9;;){if(i<=0)throw new Error(\"loop exceeded maximum allowed iterations\");t=342,i--}');
               done();
             } catch(e) {
               done();
@@ -419,6 +411,7 @@ describe('cli : domain : package-server-script', () => {
               fs.writeFileSync(path.resolve(componentPath, serverName), serverContent);
               packageServerScript(
                 {
+                  fileName: serverName,
                   componentPath: componentPath,
                   ocOptions: {
                     files: {
@@ -446,7 +439,8 @@ describe('cli : domain : package-server-script', () => {
             });
 
             it('save compiled data provide should work as expected', () => {
-              const bundle = require(path.resolve(publishPath, result.src));
+              fs.writeFileSync(path.resolve(publishPath, serverName), result);
+              const bundle = require(path.resolve(publishPath, serverName));
               const callback = sinon.spy();
               bundle.data({}, callback);
               expect(callback.args[0][0]).to.be.null;
@@ -454,8 +448,7 @@ describe('cli : domain : package-server-script', () => {
             });
 
             it('should wrap while/do/for;; loops with an iterator limit', () => {
-              const compiledContent = fs.readFileSync(path.resolve(publishPath, result.src), {encoding: 'utf8'});
-              expect(compiledContent.match(/Loop exceeded maximum allowed iterations/g).length).to.equal(3);
+              expect(result.match(/Loop exceeded maximum allowed iterations/g).length).to.equal(3);
             });
           });
         });

--- a/test/integration/cli-domain-package-server-script/cli-domain-package-server-script.js
+++ b/test/integration/cli-domain-package-server-script/cli-domain-package-server-script.js
@@ -47,7 +47,6 @@ describe('cli : domain : package-server-script', () => {
         try {
           packageServerScript(
             {
-              fileName: serverName,
               componentPath: componentPath,
               ocOptions: {
                 files: {
@@ -84,7 +83,6 @@ describe('cli : domain : package-server-script', () => {
       it('should return compiled data provider', (done) => {
         packageServerScript(
           {
-            fileName: serverName,
             componentPath: componentPath,
             ocOptions: {
               files: {
@@ -128,7 +126,6 @@ describe('cli : domain : package-server-script', () => {
       it('should save compiled data provider encapsulating json content', (done) => {
         packageServerScript(
           {
-            fileName: serverName,
             componentPath: componentPath,
             ocOptions: {
               files: {
@@ -168,7 +165,6 @@ describe('cli : domain : package-server-script', () => {
 
         packageServerScript(
           {
-            fileName: serverName,
             componentPath: componentPath,
             ocOptions: {
               files: {
@@ -199,7 +195,7 @@ describe('cli : domain : package-server-script', () => {
 
           packageServerScript(
             {
-              fileName: serverName,
+
               componentPath: componentPath,
               ocOptions: {
                 files: {
@@ -234,7 +230,7 @@ describe('cli : domain : package-server-script', () => {
 
           packageServerScript(
             {
-              fileName: serverName,
+
               componentPath: componentPath,
               ocOptions: {
                 files: {
@@ -273,7 +269,6 @@ describe('cli : domain : package-server-script', () => {
       it('should save compiled data provider encapsulating js module content', (done) => {
         packageServerScript(
           {
-            fileName: serverName,
             componentPath: componentPath,
             ocOptions: {
               files: {
@@ -309,7 +304,6 @@ describe('cli : domain : package-server-script', () => {
       it('should transpile it to es2015 through Babel', (done) => {
         packageServerScript(
           {
-            fileName: serverName,
             componentPath: componentPath,
             ocOptions: {
               files: {
@@ -352,7 +346,6 @@ describe('cli : domain : package-server-script', () => {
       it('should wrap while/do/for;; loops with an iterator limit', (done) => {
         packageServerScript(
           {
-            fileName: serverName,
             componentPath: componentPath,
             ocOptions: {
               files: {
@@ -411,7 +404,6 @@ describe('cli : domain : package-server-script', () => {
               fs.writeFileSync(path.resolve(componentPath, serverName), serverContent);
               packageServerScript(
                 {
-                  fileName: serverName,
                   componentPath: componentPath,
                   ocOptions: {
                     files: {


### PR DESCRIPTION
As per discussed on https://github.com/opentable/oc/issues/439L:

> template expose a compileServer() method that will be used instead of package-server-script/bundle

