### PR TITLE
[GPT-727] Legacy templates support

### DIFF
--- a/client/src/get-compiled-template.js
+++ b/client/src/get-compiled-template.js
@@ -25,10 +25,7 @@ module.exports = function(cache){
           });
         }
 
-        let type = template.type;
-        if (type === 'jade') { type = 'oc-template-jade'; }
-        if (type === 'handlebars') { type = 'oc-template-handlebars'; }
-
+        const type = template.type;
         let ocTemplate;
         try {
           ocTemplate = requireTemplate(type);

--- a/client/src/utils/require-template.js
+++ b/client/src/utils/require-template.js
@@ -21,6 +21,9 @@ function isValidTemplate(template){
 
 module.exports = function(template) {
   let ocTemplate;
+  if (template === 'jade') { template = 'oc-template-jade'; }
+  if (template === 'handlebars') { template = 'oc-template-handlebars'; }
+
   const localTemplate = path.join(__dirname, '../../../', 'node_modules', template);
   const relativeTemplate = path.resolve('.', 'node_modules', template);
 

--- a/src/cli/domain/package-template.js
+++ b/src/cli/domain/package-template.js
@@ -17,10 +17,6 @@ const compileView = function(viewPath, type, cb) {
   const template = fs.readFileSync(viewPath).toString();
   let ocTemplate;
 
-  if (type === 'jade') { type = 'oc-template-jade'; }
-  if (type === 'handlebars') { type = 'oc-template-handlebars'; }
-
-
   try {
     ocTemplate = requireTemplate(type);
   } catch (err) {

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -230,9 +230,7 @@ module.exports = function(conf, repository){
           } else {
             repository.getCompiledView(component.name, component.version, (err, templateText) => {
               let ocTemplate;
-              let type = component.oc.files.template.type;
-              if (type === 'jade') { type = 'oc-template-jade'; }
-              if (type === 'handlebars') { type = 'oc-template-handlebars'; }
+              const type = component.oc.files.template.type;
 
               try {
                 ocTemplate = requireTemplate(type);

--- a/src/utils/require-template.js
+++ b/src/utils/require-template.js
@@ -22,6 +22,9 @@ function isValidTemplate(template){
 
 module.exports = function(template) {
   let ocTemplate;
+  if (template === 'jade') { template = 'oc-template-jade'; }
+  if (template === 'handlebars') { template = 'oc-template-handlebars'; }
+
   const localTemplate = path.join(__dirname, '../../', 'node_modules', template);
   const relativeTemplate = path.resolve('.', 'node_modules', template);
 


### PR DESCRIPTION
Legacy template names (`jade` and `handlebars`) support is now the solely responsibility of the `require-template` module.