### PR TITLE
Hide available dependencies on dev mode

### DIFF
--- a/src/registry/views/index.pug
+++ b/src/registry/views/index.pug
@@ -18,12 +18,11 @@ block content
   h2#menuList
     a(href="#components-list" class="tab-link") Components
 
-    if componentsHistory
+    if !isLocal
       | &nbsp;|&nbsp;
       a(href="#components-history" class="tab-link") History
-
-    | &nbsp;|&nbsp;
-    a(href="#components-dependencies" class="tab-link") Available dependencies
+      | &nbsp;|&nbsp;
+      a(href="#components-dependencies" class="tab-link") Available dependencies
   
   include components-list
   include components-history


### PR DESCRIPTION
While testing #500 locally, I realised available dependencies doesn't apply locally (when in dev mode), as it is possible to install any dependency so that list is not useful.

Actually, this could be misleading as someone could think that's all the dependencies available in the real registry, and actually that's not the case.