### PR TITLE
Improve AWS upload mechanism and allow to override registry timeout settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "accept-language-parser": "1.4.0",
     "async": "2.4.1",
-    "aws-sdk": "2.62.0",
+    "aws-sdk": "2.67.0",
     "babel-core": "6.21.0",
     "babel-loader": "7.0.0",
     "babel-preset-env": "1.1.8",

--- a/src/registry/domain/options-sanitiser.js
+++ b/src/registry/domain/options-sanitiser.js
@@ -9,17 +9,15 @@ module.exports = function(input) {
   const options = _.clone(input);
 
   if (!options.publishAuth) {
-    options.beforePublish = function(req, res, next) {
-      next();
-    };
+    options.beforePublish = (req, res, next) => next();
   } else {
     options.beforePublish = auth.middleware(options.publishAuth);
   }
 
   if (!options.publishValidation) {
-    options.publishValidation = function() {
-      return { isValid: true };
-    };
+    options.publishValidation = () => ({
+      isValid: true
+    });
   }
 
   if (!options.prefix) {
@@ -50,6 +48,7 @@ module.exports = function(input) {
     .map(s => s.toLowerCase());
 
   options.port = process.env.PORT || options.port;
+  options.timeout = options.timeout || 1000 * 60 * 2;
 
   return options;
 };

--- a/src/registry/domain/s3.js
+++ b/src/registry/domain/s3.js
@@ -148,13 +148,7 @@ module.exports = function(conf) {
 
           putFile(file, url, relativeFile === '/server.js', cb);
         },
-        errors => {
-          if (errors) {
-            return callback(_.compact(errors));
-          }
-
-          callback(null, 'ok');
-        }
+        callback
       );
     });
   };
@@ -177,17 +171,17 @@ module.exports = function(conf) {
     if (fileInfo.gzip) {
       obj.ContentEncoding = 'gzip';
     }
-
-    getClient().putObject(obj, callback);
+    const upload = getClient().upload(obj);
+    upload.send(callback);
   };
 
   const putFile = (filePath, fileName, isPrivate, callback) => {
-    fs.readFile(filePath, (err, fileContent) => {
-      if (err) {
-        return callback(err);
-      }
-      putFileContent(fileContent, fileName, isPrivate, callback);
-    });
+    try {
+      const stream = fs.createReadStream(filePath);
+      putFileContent(stream, fileName, isPrivate, callback);
+    } catch (e) {
+      callback(e);
+    }
   };
 
   return {

--- a/src/registry/index.js
+++ b/src/registry/index.js
@@ -76,6 +76,7 @@ module.exports = function(options) {
         }
 
         server = http.createServer(self.app);
+        server.timeout = options.timeout;
 
         server.listen(options.port, err => {
           if (err) {

--- a/test/unit/registry-domain-options-sanitiser.js
+++ b/test/unit/registry-domain-options-sanitiser.js
@@ -1,22 +1,30 @@
 'use strict';
 
 const expect = require('chai').expect;
+const _ = require('lodash');
 
 describe('registry : domain : options-sanitiser', () => {
-
   const sanitise = require('../../src/registry/domain/options-sanitiser');
 
-  describe('when verbosity is undefined', () => {
-
+  describe('when options is empty', () => {
     const options = {};
+    const defaults = {
+      prefix: '/',
+      tempDir: './temp/',
+      hotReloading: false,
+      verbosity: 0,
+      customHeadersToSkipOnWeakVersion: [],
+      timeout: 120000
+    };
 
-    it('should set it to 0 as default', () => {
-      expect(sanitise(options).verbosity).to.equal(0);
+    _.each(defaults, (value, property) => {
+      it(`should set ${property} to ${JSON.stringify(value)}`, () => {
+        expect(sanitise(options)[property]).to.eql(value);
+      });
     });
   });
 
   describe('when verbosity is provided', () => {
-
     const options = { verbosity: 3 };
 
     it('should leave value untouched', () => {
@@ -25,39 +33,39 @@ describe('registry : domain : options-sanitiser', () => {
   });
 
   describe('customHeadersToSkipOnWeakVersion', () => {
-
-    describe('when customHeadersToSkipOnWeakVersion is undefined', () => {
-      const options = {};
-
-      it('should set it to an empty array', () => {
-        expect(sanitise(options).customHeadersToSkipOnWeakVersion).to.be.eql([]);
-      });
-    });
-
-    describe('when customHeadersToSkipOnWeakVersion contains valid elements', () => {
-      const options = {customHeadersToSkipOnWeakVersion: ['header1', 'HeAdEr-TwO', 'HEADER3']};
+    describe('when it contains valid elements', () => {
+      const options = {
+        customHeadersToSkipOnWeakVersion: ['header1', 'HeAdEr-TwO', 'HEADER3']
+      };
 
       it('should convert the array elements to lower case', () => {
-        expect(sanitise(options).customHeadersToSkipOnWeakVersion).to.be.eql(['header1', 'header-two', 'header3']);
+        expect(sanitise(options).customHeadersToSkipOnWeakVersion).to.be.eql([
+          'header1',
+          'header-two',
+          'header3'
+        ]);
       });
     });
   });
 
   describe('fallbackRegistryUrl', () => {
-
-    describe('when fallbackRegistryUrl doesn\'t contain / at the end of url', () => {
-      const options = {fallbackRegistryUrl: 'http://test-url.com'};
+    describe("when fallbackRegistryUrl doesn't contain / at the end of url", () => {
+      const options = { fallbackRegistryUrl: 'http://test-url.com' };
 
       it('should add `/` at the end of url', () => {
-        expect(sanitise(options).fallbackRegistryUrl).to.be.eql('http://test-url.com/');
+        expect(sanitise(options).fallbackRegistryUrl).to.be.eql(
+          'http://test-url.com/'
+        );
       });
     });
 
     describe('when fallbackRegistryUrl contains `/` at the end of url', () => {
-      const options = {fallbackRegistryUrl: 'http://test-url.com/'};
+      const options = { fallbackRegistryUrl: 'http://test-url.com/' };
 
       it('should not modify fallbackRegistryUrl url', () => {
-        expect(sanitise(options).fallbackRegistryUrl).to.be.eql('http://test-url.com/');
+        expect(sanitise(options).fallbackRegistryUrl).to.be.eql(
+          'http://test-url.com/'
+        );
       });
     });
   });


### PR DESCRIPTION
Fixes #514 

This Pull Request aims to address some necessary optimisations to the overall publish strategy, specifically with dealing with big components (including many and/or big files) and possibly slow connections.

In this perspective, here
1) We change the strategy for uploading to S3 from `putObject` to `upload` method. This allows uploads into multiple chunks and is necessary for files that reach big dimensions
2) We make customisable the default timeout of the API, at the moment set to 2m, so that when a publish takes a long time (because of the many requests to S3) the request is not terminated and handled correctly.

See inline comments for details about the implementation.