### PR TITLE
Fix register plugin

### DIFF
--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -138,8 +138,7 @@ module.exports = function(dependencies) {
 
     const registerPlugins = registry => {
       const mockedPlugins = getMockedPlugins(logger, componentsDir);
-
-      mockedPlugins.forEach(registry.register);
+      mockedPlugins.forEach(p => registry.register(p));
 
       registry.on('request', data => {
         if (data.errorCode === 'PLUGIN_MISSING_FROM_REGISTRY') {


### PR DESCRIPTION
This is for rolling back this little change introduced in #530 that is currently breaking the oc dev mode with mocked plugins

<img width="626" alt="screen shot 2017-07-07 at 00 30 34" src="https://user-images.githubusercontent.com/1789893/27936941-91a88c6a-62ab-11e7-8ff3-cb83d059dd1f.png">
