### PR TITLE
[OC-62] Loaders cleanup

### DIFF
--- a/src/cli/domain/package-server-script/bundle/config/index.js
+++ b/src/cli/domain/package-server-script/bundle/config/index.js
@@ -23,10 +23,10 @@ module.exports = function webpackConfigGenerator(params) {
           exclude: /node_modules/,
           use: [
             {
-              loader: 'infinite-loop-loader'
+              loader: require.resolve('infinite-loop-loader')
             },
             {
-              loader: 'babel-loader',
+              loader: require.resolve('babel-loader'),
               options: {
                 cacheDirectory: true,
                 presets: [
@@ -51,12 +51,6 @@ module.exports = function webpackConfigGenerator(params) {
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify('production')
       })
-    ],
-    resolveLoader: {
-      modules: [
-        'node_modules',
-        path.resolve(__dirname, '../../../../../../node_modules')
-      ]
-    }
+    ]
   };
 };


### PR DESCRIPTION
This is a little cleanup that adds a bit of robustness as it uses the standard resolver instead of the custom one (which breaks when oc is launched from different paths).

