### PR TITLE
Drop node4 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 
 matrix:
   include:
-    - node_js: "4"
-    - node_js: "5"
     - node_js: "6"
     - node_js: "7"
     - node_js: "8"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ version: "{build}"
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 6.11.0
+    - nodejs_version: 6
 
 # Get the stable version of node
 install:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     ]
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "repository": {
     "type": "git",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -2,6 +2,8 @@
 
 const cli = require('yargs');
 const commands = require('./commands');
+const format = require('stringformat');
+const semver = require('semver');
 const _ = require('lodash');
 
 const Local = require('./domain/local');
@@ -9,6 +11,18 @@ const logger = require('./logger');
 const Registry = require('./domain/registry');
 const strings = require('../resources');
 const validateCommand = require('./validate-command');
+
+const currentNodeVersion = process.version;
+const minSupportedVersion = '6.0.0';
+if (semver.lt(currentNodeVersion, minSupportedVersion)) {
+  logger.err(
+    format(
+      strings.errors.cli.NODE_CLI_VERSION_UNSUPPORTED,
+      currentNodeVersion,
+      minSupportedVersion
+    )
+  );
+}
 
 const dependencies = {
   local: new Local(),

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -102,6 +102,8 @@ module.exports = {
         'the name is not valid. Allowed characters are alphanumeric, _, -',
       NODE_CLI_VERSION_NEEDS_UPGRADE:
         "the version of used node is invalid. Try to upgrade node to version matching '{0}'",
+      NODE_CLI_VERSION_UNSUPPORTED:
+        "ALERT: You're currently running OC on an unsupported Node version ({0}).\nPlease upgrade Node to >= {1}.",
       OC_CLI_VERSION_NEEDS_UPGRADE:
         'the version of used OC CLI is invalid. Try to upgrade OC CLI running {0}',
       PACKAGE_CREATION_FAIL: 'An error happened when creating the package: {0}',


### PR DESCRIPTION
Context: The node client has been moved out to [his own repo](https://github.com/opencomponents/oc-client-node) and it still support node4. This allows us to now drop support for node4 on the cli/registry where we support `>=6`

Fixes #437 

