### PR TITLE
Added a mime type for html files.

### DIFF
--- a/src/utils/get-mime-type.js
+++ b/src/utils/get-mime-type.js
@@ -8,6 +8,7 @@ module.exports = function(extension) {
     '.gif': 'image/gif',
     '.jpg': 'image/jpeg',
     '.png': 'image/png',
-    '.svg': 'image/svg+xml'
+    '.svg': 'image/svg+xml',
+    '.html': 'text/html'
   }[extension];
 };

--- a/src/utils/get-mime-type.js
+++ b/src/utils/get-mime-type.js
@@ -8,7 +8,6 @@ module.exports = function(extension) {
     '.gif': 'image/gif',
     '.jpg': 'image/jpeg',
     '.png': 'image/png',
-    '.svg': 'image/svg+xml',
-    '.html': 'text/html'
+    '.svg': 'image/svg+xml'
   }[extension];
 };

--- a/test/unit/utils-get-mime-type.js
+++ b/test/unit/utils-get-mime-type.js
@@ -3,9 +3,11 @@
 const expect = require('chai').expect;
 
 describe('utils : getMimeType', () => {
+
   const getMimeType = require('../../src/utils/get-mime-type');
 
   describe('when extension is known', () => {
+
     describe('and extension is .js', () => {
       const mimeType = getMimeType('.js');
 
@@ -59,14 +61,6 @@ describe('utils : getMimeType', () => {
 
       it('should return the correct myme type', () => {
         expect(mimeType).to.equal('image/svg+xml');
-      });
-    });
-
-    describe('and extension is .html', () => {
-      const mimeType = getMimeType('.html');
-
-      it('should return the correct myme type', () => {
-        expect(mimeType).to.equal('text/html');
       });
     });
   });

--- a/test/unit/utils-get-mime-type.js
+++ b/test/unit/utils-get-mime-type.js
@@ -3,11 +3,9 @@
 const expect = require('chai').expect;
 
 describe('utils : getMimeType', () => {
-
   const getMimeType = require('../../src/utils/get-mime-type');
 
   describe('when extension is known', () => {
-
     describe('and extension is .js', () => {
       const mimeType = getMimeType('.js');
 
@@ -61,6 +59,14 @@ describe('utils : getMimeType', () => {
 
       it('should return the correct myme type', () => {
         expect(mimeType).to.equal('image/svg+xml');
+      });
+    });
+
+    describe('and extension is .html', () => {
+      const mimeType = getMimeType('.html');
+
+      it('should return the correct myme type', () => {
+        expect(mimeType).to.equal('text/html');
       });
     });
   });


### PR DESCRIPTION
I have added a mime type for html files as `text/html`.

If this is not defined at oc level and you are trying to serve the files over a front facing ngnix server (on top of oc) in a cloud environment - it would ultimately pick up the default mime type defined in ngnix which is `application/octet-stream`.

Let me know if you see any concerns here with the commit.