### PR TITLE
Removed uglify-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "stringformat": "0.0.5",
     "targz": "1.0.1",
     "try-require": "^1.2.1",
-    "uglify-js": "2.6.4",
     "watch": "1.0.2",
     "yargs": "8.0.1"
   }

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -4,7 +4,6 @@ const format = require('stringformat');
 const fs = require('fs-extra');
 const ocClientBrowser = require('oc-client-browser');
 const path = require('path');
-const uglifyJs = require('uglify-js');
 const packageJson = require('../package');
 
 module.exports = function(grunt) {


### PR DESCRIPTION
It seems that we are not using `uglify-js` anymore, so this PR to remove it.
_Greenkeeper should automatically close [this](https://github.com/opentable/oc/pull/563). If not, remember to close it once this get merged._