### PR TITLE
[OC-86] Logging href, renderMode on the component-retrieved events

### DIFF
--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -166,6 +166,26 @@ module.exports = function(conf, repository) {
           }
           componentCallbackDone = true;
 
+          const componentHref = urlBuilder.component(
+            {
+              name: component.name,
+              version: requestedComponent.version,
+              parameters: params
+            },
+            conf.baseUrl
+          );
+
+          const isUnrendered =
+              options.headers.accept ===
+              settings.registry.acceptUnrenderedHeader,
+            renderMode = isUnrendered ? 'unrendered' : 'rendered';
+
+          retrievingInfo.extend({
+            href: componentHref,
+            version: component.version,
+            renderMode
+          });
+
           if (!!err || !data) {
             err =
               err ||
@@ -187,37 +207,17 @@ module.exports = function(conf, repository) {
             });
           }
 
-          const componentHref = urlBuilder.component(
-            {
-              name: component.name,
-              version: requestedComponent.version,
-              parameters: params
-            },
-            conf.baseUrl
-          );
-
-          const isUnrendered =
-              options.headers.accept ===
-              settings.registry.acceptUnrenderedHeader,
-            renderMode = isUnrendered ? 'unrendered' : 'rendered';
-
           const response = {
             type: conf.local ? 'oc-component-local' : 'oc-component',
             version: component.version,
             requestVersion: requestedComponent.version,
             name: requestedComponent.name,
-            renderMode: renderMode
+            renderMode
           };
 
           if (!options.omitHref) {
             response.href = componentHref;
           }
-
-          retrievingInfo.extend({
-            href: componentHref,
-            version: component.version,
-            renderMode: renderMode
-          });
 
           responseHeaders = filterCustomHeaders(
             responseHeaders,

--- a/test/unit/registry-routes-helpers-get-component.js
+++ b/test/unit/registry-routes-helpers-get-component.js
@@ -6,8 +6,11 @@ const sinon = require('sinon');
 const _ = require('lodash');
 
 describe('registry : routes : helpers : get-component', () => {
-  const fireStub = sinon.stub(),
-    mockedComponents = require('../fixtures/mocked-components'),
+  const mockedComponents = require('../fixtures/mocked-components');
+  let fireStub, mockedRepository, GetComponent;
+
+  const initialise = function(params) {
+    fireStub = sinon.stub();
     GetComponent = injectr(
       '../../src/registry/routes/helpers/get-component.js',
       {
@@ -19,9 +22,6 @@ describe('registry : routes : helpers : get-component', () => {
       { console, Buffer, setTimeout }
     );
 
-  let mockedRepository, getComponent;
-
-  const initialise = function(params) {
     mockedRepository = {
       getCompiledView: sinon.stub().yields(null, params.view),
       getComponent: sinon.stub().yields(null, params.package),
@@ -31,10 +31,10 @@ describe('registry : routes : helpers : get-component', () => {
     };
   };
 
-  describe('when getting a component', () => {
+  describe('when getting a component with success', () => {
     before(done => {
       initialise(mockedComponents['async-error2-component']);
-      getComponent = new GetComponent({}, mockedRepository);
+      const getComponent = GetComponent({}, mockedRepository);
 
       getComponent(
         {
@@ -61,6 +61,39 @@ describe('registry : routes : helpers : get-component', () => {
       expect(fireStub.args[0][1].renderMode).to.equal('rendered');
       expect(fireStub.args[0][1].duration).not.to.be.empty;
       expect(fireStub.args[0][1].status).to.equal(200);
+    });
+  });
+
+  describe('when getting a component with failure', () => {
+    before(done => {
+      initialise(mockedComponents['async-error2-component']);
+      const getComponent = GetComponent({}, mockedRepository);
+
+      getComponent(
+        {
+          name: 'async-error2-component',
+          headers: {},
+          parameters: { error: true },
+          version: '1.X.X',
+          conf: { baseUrl: 'http://components.com/' }
+        },
+        () => done()
+      );
+    });
+
+    it('should fire a component-retrieved event', () => {
+      expect(fireStub.args[0][0]).to.equal('component-retrieved');
+      expect(fireStub.args[0][1].headers).to.eql({});
+      expect(fireStub.args[0][1].name).to.equal('async-error2-component');
+      expect(fireStub.args[0][1].parameters).to.eql({ error: true });
+      expect(fireStub.args[0][1].requestVersion).to.equal('1.X.X');
+      expect(fireStub.args[0][1].href).to.equal(
+        'http://components.com/async-error2-component/1.X.X?error=true'
+      );
+      expect(fireStub.args[0][1].version).to.equal('1.0.0');
+      expect(fireStub.args[0][1].renderMode).to.equal('rendered');
+      expect(fireStub.args[0][1].duration).not.to.be.empty;
+      expect(fireStub.args[0][1].status).to.equal(500);
     });
   });
 });


### PR DESCRIPTION
In case of error, the component-retrieved event was being fired without href and renderType, which are information we want to clearly log.