### PR TITLE
Saner registry default for config.discovery

### DIFF
--- a/src/registry/domain/options-sanitiser.js
+++ b/src/registry/domain/options-sanitiser.js
@@ -36,6 +36,10 @@ module.exports = function(input) {
     options.verbosity = 0;
   }
 
+  if (_.isUndefined(options.discovery)) {
+    options.discovery = true;
+  }
+
   if (
     !_.isUndefined(options.fallbackRegistryUrl) &&
     _.last(options.fallbackRegistryUrl) !== '/'


### PR DESCRIPTION
the discovery option was not documented. I've updated the wiki with it.
I suggest we set it on true by default so that is friendlier for everybody starting with OC and who follows the getting started for setting up a registry.

