### PR TITLE
Add viewport meta tag to component preview

### DIFF
--- a/src/registry/views/component-preview.pug
+++ b/src/registry/views/component-preview.pug
@@ -2,6 +2,7 @@ doctype html
 html
   head
     meta(charset="utf-8")
+    meta(name="viewport", content="width=device-width, initial-scale=1")
   body
     - var baseUrl = href.replace('http\:\/\/', '\/\/').replace('https\:\/\/', '\/\/');
     oc-component(href=baseUrl+component.name+'/'+component.version+'/'+qs)


### PR DESCRIPTION
Without a viewport, mobile devices will render the page at a typical desktop screen width, scaled to fit the screen. More info: https://developers.google.com/speed/docs/insights/ConfigureViewport

It would be useful to preview components from a mobile device and see them rendered and scaled correctly.

I'm sorry I haven't created an issue please let me know if you need me to create one.