### PR TITLE
[OC-103]

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "multer": "^1.3.0",
     "nice-cache": "0.0.5",
     "node-dir": "0.1.16",
-    "npm": "5.0.2",
+    "npm": "5.3.0",
     "oc-client-browser": "1.0.1",
     "oc-client": "2.1.21",
     "oc-template-handlebars": "6.0.2",

--- a/src/cli/domain/get-missing-deps.js
+++ b/src/cli/domain/get-missing-deps.js
@@ -21,7 +21,7 @@ module.exports = dependencies => {
         delete require.cache[pathToModule];
       }
 
-      require(pathToModule);
+      require.resolve(pathToModule);
     } catch (e) {
       missing.push(npmModule);
     }


### PR DESCRIPTION
This fix #591 

Quick overview:
- some packages that are not requirable (ie [fbjs](https://github.com/facebook/fbjs/blob/master/packages/fbjs/index.js)) directly were throwing errors when checking their installation through `require()`. Using `require.resolve()` instead address those cases.
- some bugs when installing through `npm` were also fixed by updating to latest `npm`