### PR TITLE
Add ability to disable watching on local dev registry

### DIFF
--- a/src/cli/commands.js
+++ b/src/cli/commands.js
@@ -27,6 +27,11 @@ module.exports = {
           boolean: true,
           description: 'Verbosity',
           default: false
+        },
+        watch: {
+          boolean: true,
+          description: 'Watch for file changes',
+          default: true
         }
       },
       usage: 'Usage: $0 dev <dirName> [port] [baseUrl] [options]'

--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -25,7 +25,8 @@ module.exports = function(dependencies) {
       fallbackRegistryUrl = opts.fallbackRegistryUrl,
       hotReloading = _.isUndefined(opts.hotReloading)
         ? true
-        : opts.hotReloading;
+        : opts.hotReloading,
+      optWatch = _.isUndefined(opts.watch) ? true : opts.watch;
     let packaging = false;
 
     callback = wrapCliCallback(callback);
@@ -159,7 +160,9 @@ module.exports = function(dependencies) {
               return callback(err);
             }
 
-            watchForChanges(components, packageComponents);
+            if (optWatch) {
+              watchForChanges(components, packageComponents);
+            }
             callback(null, registry);
           });
         });


### PR DESCRIPTION
For our use case, we run visuals tests against the local dev registry. This process saves screenshots to disk which then kicks off an OC package task and sometimes this errors out whilst the visual tests are running. We'd love to be able to disable watching for this scenario.

Would need to update: https://github.com/opentable/oc/wiki/Cli