### PR TITLE
[OC-102] Return rendered version if client doesn't support

### DIFF
--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -249,19 +249,36 @@ module.exports = function(conf, repository) {
             component.version
           );
 
-          if (renderMode === 'rendered') {
-            const cacheKey = `${component.name}/${component.version}/template.js`,
-              cached = cache.get('file-contents', cacheKey),
-              key = component.oc.files.template.hashKey,
-              renderOptions = {
-                href: componentHref,
-                key,
-                version: component.version,
-                name: component.name,
-                templateType: component.oc.files.template.type,
-                container: component.oc.container,
-                renderInfo: component.oc.renderInfo
-              };
+          if (renderMode === 'unrendered') {
+            callback({
+              status: 200,
+              headers: responseHeaders,
+              response: _.extend(response, {
+                data: data,
+                template: {
+                  src: repository.getStaticFilePath(
+                    component.name,
+                    component.version,
+                    'template.js'
+                  ),
+                  type: component.oc.files.template.type,
+                  key: component.oc.files.template.hashKey
+                }
+              })
+            });
+          } else {
+            const cacheKey = `${component.name}/${component.version}/template.js`;
+            const cached = cache.get('file-contents', cacheKey);
+            const key = component.oc.files.template.hashKey;
+            const renderOptions = {
+              href: componentHref,
+              key,
+              version: component.version,
+              name: component.name,
+              templateType: component.oc.files.template.type,
+              container: component.oc.container,
+              renderInfo: component.oc.renderInfo
+            };
 
             const returnResult = template => {
               client.renderTemplate(
@@ -312,23 +329,6 @@ module.exports = function(conf, repository) {
                 }
               );
             }
-          } else {
-            callback({
-              status: 200,
-              headers: responseHeaders,
-              response: _.extend(response, {
-                data: data,
-                template: {
-                  src: repository.getStaticFilePath(
-                    component.name,
-                    component.version,
-                    'template.js'
-                  ),
-                  type: component.oc.files.template.type,
-                  key: component.oc.files.template.hashKey
-                }
-              })
-            });
           }
         };
 

--- a/test/unit/registry-routes-helpers-get-component.js
+++ b/test/unit/registry-routes-helpers-get-component.js
@@ -129,7 +129,7 @@ describe('registry : routes : helpers : get-component', () => {
     });
   });
 
-  describe('when oc-client request an unrendered component and it support the correct template', () => {
+  describe('when oc-client requests an unrendered component and it support the correct template', () => {
     const headers = {
       'user-agent': 'oc-client-0/0-0-0',
       templates: { 'oc-template-jade': true },

--- a/test/unit/registry-routes-helpers-get-component.js
+++ b/test/unit/registry-routes-helpers-get-component.js
@@ -96,4 +96,72 @@ describe('registry : routes : helpers : get-component', () => {
       expect(fireStub.args[0][1].status).to.equal(500);
     });
   });
+
+  describe("when oc-client request an unrendered component and it doesn't support the correct template", () => {
+    const headers = {
+      'user-agent': 'oc-client-0/0-0-0',
+      templates: {},
+      accept: 'application/vnd.oc.unrendered+json'
+    };
+    let callBack;
+
+    before(done => {
+      initialise(mockedComponents['async-error2-component']);
+      const getComponent = GetComponent({}, mockedRepository);
+      callBack = sinon.spy(() => done());
+      getComponent(
+        {
+          name: 'async-error2-component',
+          headers,
+          parameters: {},
+          version: '1.X.X',
+          conf: { baseUrl: 'http://components.com/' }
+        },
+        callBack
+      );
+    });
+
+    it('should return the rendered version instead', () => {
+      expect(callBack.args[0][0].response.template).to.equal(undefined);
+      expect(callBack.args[0][0].response.html).to.equal('<div>hello</div>');
+      expect(callBack.args[0][0].response.renderMode).to.equal('rendered');
+      expect(fireStub.args[0][1].renderMode).to.equal('rendered');
+    });
+  });
+
+  describe('when oc-client request an unrendered component and it support the correct template', () => {
+    const headers = {
+      'user-agent': 'oc-client-0/0-0-0',
+      templates: { 'oc-template-jade': true },
+      accept: 'application/vnd.oc.unrendered+json'
+    };
+    let callBack;
+
+    before(done => {
+      initialise(mockedComponents['async-error2-component']);
+      const getComponent = GetComponent({}, mockedRepository);
+      callBack = sinon.spy(() => done());
+      getComponent(
+        {
+          name: 'async-error2-component',
+          headers,
+          parameters: {},
+          version: '1.X.X',
+          conf: { baseUrl: 'http://components.com/' }
+        },
+        callBack
+      );
+    });
+
+    it('should return the unrendered version', () => {
+      expect(callBack.args[0][0].response.html).to.equal(undefined);
+      expect(callBack.args[0][0].response.template).to.deep.equal({
+        key: '8c1fbd954f2b0d8cd5cf11c885fed4805225749f',
+        src: '//my-cdn.com/files/',
+        type: 'jade'
+      });
+      expect(callBack.args[0][0].response.renderMode).to.equal('unrendered');
+      expect(fireStub.args[0][1].renderMode).to.equal('unrendered');
+    });
+  });
 });


### PR DESCRIPTION
Related to (and blocked by) 

- https://github.com/opencomponents/oc-client-node/pull/8
- https://github.com/opencomponents/oc-client-node/pull/9

Registry will handle server side rendering in case of oc-client requesting the unrendered version of an unsupported template
