### PR TITLE
Pass option to the compiler for targeting specific build process

### DIFF
--- a/src/cli/commands.js
+++ b/src/cli/commands.js
@@ -32,6 +32,11 @@ module.exports = {
           boolean: true,
           description: 'Watch for file changes',
           default: true
+        },
+        production: {
+          boolean: true,
+          description: 'Force packaging for production',
+          default: false
         }
       },
       usage: 'Usage: $0 dev <dirName> [port] [baseUrl] [options]'

--- a/src/cli/domain/package-components.js
+++ b/src/cli/domain/package-components.js
@@ -8,6 +8,7 @@ const validator = require('../../registry/domain/validators');
 
 module.exports = function() {
   return function(options, callback) {
+    const build = options.build;
     const componentPath = options.componentPath;
     const minify = options.minify === true;
     const verbose = options.verbose === true;
@@ -39,7 +40,8 @@ module.exports = function() {
       componentPackage,
       ocPackage,
       minify,
-      verbose
+      verbose,
+      build
       // TODO: logger,
       // TODO: watch,
     };

--- a/src/cli/domain/package-components.js
+++ b/src/cli/domain/package-components.js
@@ -8,7 +8,7 @@ const validator = require('../../registry/domain/validators');
 
 module.exports = function() {
   return function(options, callback) {
-    const build = options.build;
+    const production = options.production;
     const componentPath = options.componentPath;
     const minify = options.minify === true;
     const verbose = options.verbose === true;
@@ -41,7 +41,7 @@ module.exports = function() {
       ocPackage,
       minify,
       verbose,
-      build
+      production
       // TODO: logger,
       // TODO: watch,
     };

--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -64,7 +64,7 @@ module.exports = function(dependencies) {
               componentPath: dir,
               minify: false,
               verbose: opts.verbose,
-              build: opts['P'] ? 'production' : 'development'
+              production: Boolean(opts['production'])
             };
 
             local.package(packageOptions, err => {

--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -63,7 +63,8 @@ module.exports = function(dependencies) {
             const packageOptions = {
               componentPath: dir,
               minify: false,
-              verbose: opts.verbose
+              verbose: opts.verbose,
+              build: opts['P'] ? 'production' : 'development'
             };
 
             local.package(packageOptions, err => {

--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -64,7 +64,7 @@ module.exports = function(dependencies) {
               componentPath: dir,
               minify: false,
               verbose: opts.verbose,
-              production: Boolean(opts['production'])
+              production: opts['production']
             };
 
             local.package(packageOptions, err => {

--- a/src/cli/facade/package.js
+++ b/src/cli/facade/package.js
@@ -18,7 +18,7 @@ module.exports = function(dependencies) {
 
     logger.warn(format(strings.messages.cli.PACKAGING, packageDir));
     const packageOptions = {
-      build: 'production',
+      production: true,
       componentPath: path.resolve(componentPath)
     };
     local.package(packageOptions, (err, component) => {

--- a/src/cli/facade/package.js
+++ b/src/cli/facade/package.js
@@ -18,6 +18,7 @@ module.exports = function(dependencies) {
 
     logger.warn(format(strings.messages.cli.PACKAGING, packageDir));
     const packageOptions = {
+      build: 'production',
       componentPath: path.resolve(componentPath)
     };
     local.package(packageOptions, (err, component) => {

--- a/src/cli/facade/publish.js
+++ b/src/cli/facade/publish.js
@@ -45,6 +45,7 @@ module.exports = function(dependencies) {
     const packageAndCompress = function(cb) {
       logger.warn(format(strings.messages.cli.PACKAGING, packageDir));
       const packageOptions = {
+        build: 'production',
         componentPath: path.resolve(componentPath)
       };
       local.package(packageOptions, (err, component) => {

--- a/src/cli/facade/publish.js
+++ b/src/cli/facade/publish.js
@@ -45,7 +45,7 @@ module.exports = function(dependencies) {
     const packageAndCompress = function(cb) {
       logger.warn(format(strings.messages.cli.PACKAGING, packageDir));
       const packageOptions = {
-        build: 'production',
+        production: true,
         componentPath: path.resolve(componentPath)
       };
       local.package(packageOptions, (err, component) => {


### PR DESCRIPTION
The following PR will pass an option to the compiler called `build`.
- when running the cli `dev` build value is automatically set to `development` (can be override if needed by passing the flag `-P` when running the cli)
- when running `package` or `publish` build is automatically set to `production` (and cannot be oveririden)

This will allow for template that support this to avoid complex processes like minifications, in order to offer a faster feedback-loop while developing  #components and allow to enable more complex debugging tools like full sourcemaps, or react dev tools.