### PR TITLE
[OC-140] Declarative templates initialisation on a registry level

### DIFF
--- a/src/registry/domain/register-templates.js
+++ b/src/registry/domain/register-templates.js
@@ -1,0 +1,31 @@
+const handlebarsTemplate = require('oc-template-handlebars');
+const jadeTemplate = require('oc-template-jade');
+const _ = require('lodash');
+
+module.exports = function(extraTemplates) {
+  const coreTemplates = [jadeTemplate, handlebarsTemplate];
+  const templates = _.union(coreTemplates, extraTemplates);
+  const templatesHash = templates.reduce((hash, template) => {
+    try {
+      const type = template.getInfo().type;
+      hash[type] = template;
+      return hash;
+    } catch (err) {
+      throw err;
+    }
+  }, {});
+
+  const templatesInfo = templates.map(template => {
+    try {
+      return template.getInfo();
+    } catch (err) {
+      throw err;
+    }
+  });
+
+  return {
+    templates,
+    templatesHash,
+    templatesInfo
+  };
+};

--- a/src/registry/domain/register-templates.js
+++ b/src/registry/domain/register-templates.js
@@ -24,7 +24,6 @@ module.exports = function(extraTemplates) {
   });
 
   return {
-    templates,
     templatesHash,
     templatesInfo
   };

--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -9,12 +9,12 @@ const _ = require('lodash');
 const ComponentsCache = require('./components-cache');
 const ComponentsDetails = require('./components-details');
 const packageInfo = require('../../../package.json');
-const requireTemplate = require('../../utils/require-template');
 const S3 = require('./s3');
 const settings = require('../../resources/settings');
 const strings = require('../../resources');
 const validator = require('./validators');
 const versionHandler = require('./version-handler');
+const registerTemplates = require('./register-templates');
 
 module.exports = function(conf) {
   const cdn = !conf.local && new S3(conf);
@@ -25,20 +25,9 @@ module.exports = function(conf) {
   const getFilePath = (component, version, filePath) =>
     `${conf.s3.componentsDir}/${component}/${version}/${filePath}`;
 
-  const coreTemplates = ['oc-template-jade', 'oc-template-handlebars'];
-  const templates = _.union(coreTemplates, conf.templates).map(template => {
-    try {
-      const ocTemplate = requireTemplate(template);
-      const info = ocTemplate.getInfo();
-      return {
-        type: info.type,
-        version: info.version,
-        externals: info.externals
-      };
-    } catch (err) {
-      throw err;
-    }
-  });
+  const { templatesHash, templatesInfo, templates } = registerTemplates(
+    conf.templates
+  );
 
   const local = {
     getCompiledView: componentName => {
@@ -276,7 +265,8 @@ module.exports = function(conf) {
         ? settings.registry.localStaticRedirectorPath
         : ''}${filePath}`,
 
-    getTemplates: () => templates,
+    getTemplatesInfo: () => templatesInfo,
+    getTemplate: type => templatesHash[type],
 
     init: callback => {
       if (conf.local) {

--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -9,12 +9,12 @@ const _ = require('lodash');
 const ComponentsCache = require('./components-cache');
 const ComponentsDetails = require('./components-details');
 const packageInfo = require('../../../package.json');
+const registerTemplates = require('./register-templates');
 const S3 = require('./s3');
 const settings = require('../../resources/settings');
 const strings = require('../../resources');
 const validator = require('./validators');
 const versionHandler = require('./version-handler');
-const registerTemplates = require('./register-templates');
 
 module.exports = function(conf) {
   const cdn = !conf.local && new S3(conf);
@@ -25,9 +25,7 @@ module.exports = function(conf) {
   const getFilePath = (component, version, filePath) =>
     `${conf.s3.componentsDir}/${component}/${version}/${filePath}`;
 
-  const { templatesHash, templatesInfo, templates } = registerTemplates(
-    conf.templates
-  );
+  const { templatesHash, templatesInfo } = registerTemplates(conf.templates);
 
   const local = {
     getCompiledView: componentName => {

--- a/src/registry/routes/component-preview.js
+++ b/src/registry/routes/component-preview.js
@@ -50,7 +50,7 @@ module.exports = function(conf, repository) {
                 req,
                 res,
                 fallbackComponent,
-                repository.getTemplates()
+                repository.getTemplatesInfo()
               );
             }
           );
@@ -61,7 +61,7 @@ module.exports = function(conf, repository) {
           req,
           res,
           component,
-          repository.getTemplates()
+          repository.getTemplatesInfo()
         );
       }
     );

--- a/src/registry/routes/helpers/get-component.js
+++ b/src/registry/routes/helpers/get-component.js
@@ -19,7 +19,6 @@ const settings = require('../../../resources/settings');
 const strings = require('../../../resources');
 const urlBuilder = require('../../domain/url-builder');
 const validator = require('../../domain/validators');
-const requireTemplate = require('../../../utils/require-template');
 
 module.exports = function(conf, repository) {
   const client = new Client(),
@@ -153,9 +152,7 @@ module.exports = function(conf, repository) {
           templateType = `oc-template-${templateType}`;
         }
 
-        const supportedTemplates = repository.getTemplates().map(t => t.type);
-
-        if (!_.includes(supportedTemplates, templateType)) {
+        if (!repository.getTemplate(templateType)) {
           return callback({
             status: 400,
             response: {
@@ -344,7 +341,7 @@ module.exports = function(conf, repository) {
                   let ocTemplate;
 
                   try {
-                    ocTemplate = requireTemplate(templateType);
+                    ocTemplate = repository.getTemplate(templateType);
                   } catch (err) {
                     throw err;
                   }
@@ -392,7 +389,7 @@ module.exports = function(conf, repository) {
                   responseHeaders[header.toLowerCase()] = value;
                 }
               },
-              templates: repository.getTemplates()
+              templates: repository.getTemplatesInfo()
             };
 
           const setCallbackTimeout = () => {

--- a/test/unit/registry-domain-register-templates.js
+++ b/test/unit/registry-domain-register-templates.js
@@ -7,11 +7,10 @@ const sinon = require('sinon');
 describe('registry : domain : register-templates', () => {
   const registerTemplates = require('../../src/registry/domain/register-templates.js');
 
-  describe('when templates get registerd without additional templates', () => {
+  describe('when templates get registered without additional templates', () => {
     const registerd = registerTemplates();
 
     it('should correctly register core-templates', () => {
-      expect(registerd.templates.length).to.eql(2);
       expect(registerd.templatesHash).to.deep.eql({
         'oc-template-jade': require('oc-template-jade'),
         'oc-template-handlebars': require('oc-template-handlebars')
@@ -23,7 +22,7 @@ describe('registry : domain : register-templates', () => {
     });
   });
 
-  describe('when templates get registerd with additional templates', () => {
+  describe('when templates get registered with additional templates', () => {
     const templateMock = {
       getInfo() {
         return {
@@ -37,7 +36,6 @@ describe('registry : domain : register-templates', () => {
     const registerd = registerTemplates([templateMock]);
 
     it('should correctly register core-templates & extra templates', () => {
-      expect(registerd.templates.length).to.eql(3);
       expect(registerd.templatesHash).to.deep.eql({
         'oc-template-jade': require('oc-template-jade'),
         'oc-template-handlebars': require('oc-template-handlebars'),
@@ -54,7 +52,6 @@ describe('registry : domain : register-templates', () => {
       const registerd = registerTemplates([require('oc-template-jade')]);
 
       it('should correctly register core-templates only', () => {
-        expect(registerd.templates.length).to.eql(2);
         expect(registerd.templatesHash).to.deep.eql({
           'oc-template-jade': require('oc-template-jade'),
           'oc-template-handlebars': require('oc-template-handlebars')

--- a/test/unit/registry-domain-register-templates.js
+++ b/test/unit/registry-domain-register-templates.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const expect = require('chai').expect;
+const injectr = require('injectr');
+const sinon = require('sinon');
+
+describe('registry : domain : register-templates', () => {
+  const registerTemplates = require('../../src/registry/domain/register-templates.js');
+
+  describe('when templates get registerd without additional templates', () => {
+    const registerd = registerTemplates();
+
+    it('should correctly register core-templates', () => {
+      expect(registerd.templates.length).to.eql(2);
+      expect(registerd.templatesHash).to.deep.eql({
+        'oc-template-jade': require('oc-template-jade'),
+        'oc-template-handlebars': require('oc-template-handlebars')
+      });
+      expect(registerd.templatesInfo).to.deep.eql([
+        require('oc-template-jade').getInfo(),
+        require('oc-template-handlebars').getInfo()
+      ]);
+    });
+  });
+
+  describe('when templates get registerd with additional templates', () => {
+    const templateMock = {
+      getInfo() {
+        return {
+          type: 'new-tpl',
+          version: '6.6.6',
+          externals: {}
+        };
+      }
+    };
+
+    const registerd = registerTemplates([templateMock]);
+
+    it('should correctly register core-templates & extra templates', () => {
+      expect(registerd.templates.length).to.eql(3);
+      expect(registerd.templatesHash).to.deep.eql({
+        'oc-template-jade': require('oc-template-jade'),
+        'oc-template-handlebars': require('oc-template-handlebars'),
+        'new-tpl': templateMock
+      });
+      expect(registerd.templatesInfo).to.deep.eql([
+        require('oc-template-jade').getInfo(),
+        require('oc-template-handlebars').getInfo(),
+        templateMock.getInfo()
+      ]);
+    });
+
+    describe('and additional template is already part of core-templates', () => {
+      const registerd = registerTemplates([require('oc-template-jade')]);
+
+      it('should correctly register core-templates only', () => {
+        expect(registerd.templates.length).to.eql(2);
+        expect(registerd.templatesHash).to.deep.eql({
+          'oc-template-jade': require('oc-template-jade'),
+          'oc-template-handlebars': require('oc-template-handlebars')
+        });
+        expect(registerd.templatesInfo).to.deep.eql([
+          require('oc-template-jade').getInfo(),
+          require('oc-template-handlebars').getInfo()
+        ]);
+      });
+    });
+  });
+});

--- a/test/unit/registry-domain-repository.js
+++ b/test/unit/registry-domain-repository.js
@@ -128,11 +128,11 @@ describe('registry : domain : repository', () => {
     describe('when getting the list of supported templates', () => {
       describe('when no templates are specificed on the configuaration', () => {
         it('should return core templates', () => {
-          expect(repository.getTemplates().length).to.equal(2);
-          expect(repository.getTemplates()[0].type).to.equal(
+          expect(repository.getTemplatesInfo().length).to.equal(2);
+          expect(repository.getTemplatesInfo()[0].type).to.equal(
             'oc-template-jade'
           );
-          expect(repository.getTemplates()[1].type).to.equal(
+          expect(repository.getTemplatesInfo()[1].type).to.equal(
             'oc-template-handlebars'
           );
         });
@@ -141,24 +141,23 @@ describe('registry : domain : repository', () => {
       describe('when the templates specificed on the configuaration are core-templates', () => {
         it('should only return uniques templates', () => {
           const conf = _.extend(cdnConfiguration, {
-            templates: ['oc-template-jade']
+            templates: [require('oc-template-jade')]
           });
           const repository = new Repository(conf);
-          expect(repository.getTemplates().length).to.equal(2);
+          expect(repository.getTemplatesInfo().length).to.equal(2);
         });
       });
 
       describe('when templates specificed on the configuaration are not installed', () => {
         it('should throw an error', () => {
-          const conf = _.extend(cdnConfiguration, {
-            templates: ['oc-template-react']
-          });
-
           try {
+            const conf = _.extend(cdnConfiguration, {
+              templates: [require('oc-template-react')]
+            });
             Repository(conf);
           } catch (err) {
             expect(err.message).to.equal(
-              'Error requiring oc-template: "oc-template-react" not found'
+              "Cannot find module 'oc-template-react'"
             );
           }
         });

--- a/test/unit/registry-routes-component.js
+++ b/test/unit/registry-routes-component.js
@@ -9,6 +9,10 @@ describe('registry : routes : component', () => {
     mockedComponents = require('../fixtures/mocked-components');
   let mockedRepository, resJsonStub, resSetStub, statusStub, componentRoute;
 
+  const templates = {
+    'oc-template-jade': require('oc-template-jade'),
+    'oc-template-handlebars': require('oc-template-handlebars')
+  };
   const initialise = function(params) {
     resJsonStub = sinon.stub();
     resSetStub = sinon.stub();
@@ -17,7 +21,7 @@ describe('registry : routes : component', () => {
       getCompiledView: sinon.stub().yields(null, params.view),
       getComponent: sinon.stub().yields(null, params.package),
       getDataProvider: sinon.stub().yields(null, params.data),
-      getTemplates: sinon.stub().returns([
+      getTemplatesInfo: sinon.stub().returns([
         {
           type: 'oc-template-jade',
           version: '6.0.1',
@@ -29,6 +33,7 @@ describe('registry : routes : component', () => {
           externals: []
         }
       ]),
+      getTemplate: type => templates[type],
       getStaticFilePath: sinon.stub().returns('//my-cdn.com/files/')
     };
   };
@@ -574,12 +579,16 @@ describe('registry : routes : component', () => {
       const headersComponent =
         mockedComponents['another-response-headers-component'];
       const simpleComponent = mockedComponents['simple-component'];
+      const templates = {
+        'oc-template-jade': require('oc-template-jade'),
+        'oc-template-handlebars': require('oc-template-handlebars')
+      };
 
       mockedRepository = {
         getCompiledView: sinon.stub(),
         getComponent: sinon.stub(),
         getDataProvider: sinon.stub(),
-        getTemplates: sinon.stub().returns([
+        getTemplatesInfo: sinon.stub().returns([
           {
             type: 'oc-template-jade',
             version: '6.0.1',
@@ -591,6 +600,7 @@ describe('registry : routes : component', () => {
             externals: []
           }
         ]),
+        getTemplate: type => templates[type],
         getStaticFilePath: sinon.stub().returns('//my-cdn.com/files/')
       };
 

--- a/test/unit/registry-routes-components.js
+++ b/test/unit/registry-routes-components.js
@@ -8,13 +8,17 @@ describe('registry : routes : components', () => {
     mockedComponents = require('../fixtures/mocked-components');
 
   let mockedRepository, componentsRoute, code, response;
+  const templates = {
+    'oc-template-jade': require('oc-template-jade'),
+    'oc-template-handlebars': require('oc-template-handlebars')
+  };
 
   const initialise = function(params) {
     mockedRepository = {
       getCompiledView: sinon.stub().yields(null, params.view),
       getComponent: sinon.stub().yields(null, params.package),
       getDataProvider: sinon.stub().yields(null, params.data),
-      getTemplates: sinon.stub().returns([
+      getTemplatesInfo: sinon.stub().returns([
         {
           type: 'oc-template-jade',
           version: '6.0.1',
@@ -26,6 +30,7 @@ describe('registry : routes : components', () => {
           externals: []
         }
       ]),
+      getTemplate: type => templates[type],
       getStaticFilePath: sinon.stub().returns('//my-cdn.com/files/')
     };
   };

--- a/test/unit/registry-routes-helpers-get-component.js
+++ b/test/unit/registry-routes-helpers-get-component.js
@@ -9,7 +9,10 @@ const _ = require('lodash');
 describe('registry : routes : helpers : get-component', () => {
   const mockedComponents = require('../fixtures/mocked-components');
   let fireStub, mockedRepository, GetComponent;
-
+  const templates = {
+    'oc-template-jade': require('oc-template-jade'),
+    'oc-template-handlebars': require('oc-template-handlebars')
+  };
   const initialise = function(params) {
     fireStub = sinon.stub();
     GetComponent = injectr(
@@ -18,13 +21,6 @@ describe('registry : routes : helpers : get-component', () => {
         '../../domain/events-handler': {
           on: _.noop,
           fire: fireStub
-        },
-        '../../../utils/require-template': type => {
-          if (type === 'oc-template-supported') {
-            return require('oc-template-jade');
-          } else {
-            return require(type);
-          }
         },
         'oc-client': function() {
           const client = new Client();
@@ -45,7 +41,7 @@ describe('registry : routes : helpers : get-component', () => {
       getCompiledView: sinon.stub().yields(null, params.view),
       getComponent: sinon.stub().yields(null, params.package),
       getDataProvider: sinon.stub().yields(null, params.data),
-      getTemplates: sinon.stub().returns([
+      getTemplatesInfo: sinon.stub().returns([
         {
           type: 'oc-template-jade',
           version: '6.0.1',
@@ -62,6 +58,10 @@ describe('registry : routes : helpers : get-component', () => {
           externals: []
         }
       ]),
+      getTemplate: type =>
+        type === 'oc-template-supported'
+          ? templates['oc-template-jade']
+          : templates[type],
       getStaticFilePath: sinon.stub().returns('//my-cdn.com/files/')
     };
   };


### PR DESCRIPTION
 Templates declaration is now more explicit when configuring the registry (same API as per the node client):
```
conf = {
...
templates: [require('oc-template-react')]
...
}
```