### PR TITLE
Improve watching for Dev registry

### DIFF
--- a/src/cli/domain/watch.js
+++ b/src/cli/domain/watch.js
@@ -8,6 +8,7 @@ module.exports = function(dirs, baseDir, changed) {
     watch.watchTree(
       path.resolve(baseDir),
       {
+        interval: 0.5,
         ignoreUnreadableDir: true,
         ignoreDotFiles: false
       },
@@ -18,7 +19,8 @@ module.exports = function(dirs, baseDir, changed) {
               fileName
             ) === false
           ) {
-            changed(null, fileName);
+            const componentDir = dirs.find(dir => Boolean(fileName.match(dir)));
+            changed(null, fileName, componentDir);
           }
         }
       }

--- a/src/cli/domain/watch.js
+++ b/src/cli/domain/watch.js
@@ -10,18 +10,16 @@ module.exports = function(dirs, baseDir, changed) {
       {
         interval: 0.5,
         ignoreUnreadableDir: true,
-        ignoreDotFiles: false
+        ignoreDotFiles: false,
+        filter: fileOrDir =>
+          /node_modules|package\.tar\.gz|_package|\.sw[op]|\.git|\.DS_Store|oc\.json/.test(
+            fileOrDir
+          ) === false
       },
       (fileName, currentStat, previousStat) => {
         if (!!currentStat || !!previousStat) {
-          if (
-            /node_modules|package\.tar\.gz|_package|\.sw[op]|\.git|\.DS_Store/gi.test(
-              fileName
-            ) === false
-          ) {
-            const componentDir = dirs.find(dir => Boolean(fileName.match(dir)));
-            changed(null, fileName, componentDir);
-          }
+          const componentDir = dirs.find(dir => Boolean(fileName.match(dir)));
+          changed(null, fileName, componentDir);
         }
       }
     );

--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -34,7 +34,7 @@ module.exports = function(dependencies) {
     callback = wrapCliCallback(callback);
 
     const watchForChanges = function({ components, liveReloadServer }, cb) {
-      watch(components, componentsDir, (err, changedFile) => {
+      watch(components, componentsDir, (err, changedFile, componentDir) => {
         if (err) {
           logger.err(format(strings.errors.generic, err));
         } else {
@@ -44,7 +44,7 @@ module.exports = function(dependencies) {
           if (!hotReloading) {
             logger.warn(strings.messages.cli.HOT_RELOADING_DISABLED);
           } else {
-            cb(components, done => {
+            cb([componentDir], done => {
               liveReloadServer.refresh('/');
             });
           }


### PR DESCRIPTION
This PR addresses #351:

- [x] when on dev mode, only the component that was changed get re-compiled, not all the components. This should reduce feedback-loop times quite a bit when working in projects containing more components.
- [x] ignored files/dirs are now fully ignored from the tree of files to watch

Because of the combination of the two points above most of the reported issues should be address without the need for the user to explicitly define an ignore list.
