### PR TITLE
Issue #379 support for minio

### DIFF
--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -51,8 +51,8 @@ module.exports = function(conf) {
         const isDir = fs.lstatSync(path.join(conf.path, file)).isDirectory();
         const isValidComponent = isDir
           ? fs
-              .readdirSync(path.join(conf.path, file))
-              .filter(file => file === '_package').length === 1
+            .readdirSync(path.join(conf.path, file))
+            .filter(file => file === '_package').length === 1
           : false;
 
         return isValidComponent;
@@ -196,9 +196,12 @@ module.exports = function(conf) {
       );
     },
     getComponentPath: (componentName, componentVersion) => {
+      const basePath = conf.s3.path.startsWith('http')
+        ? conf.s3.path
+        : `https:${conf.s3.path}`;
       const prefix = conf.local
         ? conf.baseUrl
-        : `https:${conf.s3.path}${conf.s3.componentsDir}/`;
+        : `${basePath}${conf.s3.componentsDir}/`;
       return `${prefix}${componentName}/${componentVersion}/`;
     },
     getComponents: callback => {

--- a/src/registry/domain/s3.js
+++ b/src/registry/domain/s3.js
@@ -30,7 +30,7 @@ const getConfig = conf => {
   if (conf.s3.region) {
     config.region = conf.s3.region;
   }
-  if (conf.s3.region) {
+  if (conf.s3.signatureVersion) {
     config.signatureVersion = conf.s3.signatureVersion;
   }
   if (conf.s3.s3ForcePathStyle) {

--- a/src/registry/domain/s3.js
+++ b/src/registry/domain/s3.js
@@ -12,18 +12,40 @@ const getFileInfo = require('../../utils/get-file-info');
 const getNextYear = require('../../utils/get-next-year');
 const strings = require('../../resources');
 
+const getConfig = conf => {
+  const httpOptions = { timeout: conf.s3.timeout || 10000 };
+  if (conf.s3.agentProxy) {
+    httpOptions.agent = conf.s3.agentProxy;
+  }
+
+  const config = {
+    accessKeyId: conf.s3.key,
+    secretAccessKey: conf.s3.secret,
+    httpOptions
+  };
+
+  if (conf.s3.endpoint) {
+    config.endpoint = conf.s3.endpoint;
+  }
+  if (conf.s3.region) {
+    config.region = conf.s3.region;
+  }
+  if (conf.s3.region) {
+    config.signatureVersion = conf.s3.signatureVersion;
+  }
+  if (conf.s3.s3ForcePathStyle) {
+    config.s3ForcePathStyle = conf.s3.s3ForcePathStyle;
+  }
+  return config;
+};
+
 module.exports = function(conf) {
   const httpOptions = { timeout: conf.s3.timeout || 10000 };
   if (conf.s3.agentProxy) {
     httpOptions.agent = conf.s3.agentProxy;
   }
 
-  AWS.config.update({
-    accessKeyId: conf.s3.key,
-    secretAccessKey: conf.s3.secret,
-    region: conf.s3.region,
-    httpOptions
-  });
+  AWS.config.update(getConfig(conf));
 
   const bucket = conf.s3.bucket;
   const cache = new Cache({

--- a/src/registry/domain/validators/registry-configuration.js
+++ b/src/registry/domain/validators/registry-configuration.js
@@ -89,7 +89,7 @@ module.exports = function(conf) {
     if (
       !conf.s3 ||
       !conf.s3.bucket ||
-      !conf.s3.region ||
+      (!conf.s3.region && !conf.s3.endpoint) ||
       (conf.s3.key && !conf.s3.secret) ||
       (!conf.s3.key && conf.s3.secret)
     ) {


### PR DESCRIPTION
Add support for minio via endpoint s3 config.

Example:

endpoint: 'http://minio.local:9000',
    path: 'http://minio.local:9000/oc-registry/',
    s3ForcePathStyle: 'true',
    signatureVersion: 'v4',