### PR TITLE
Error publish

### DIFF
--- a/src/registry/app-start.js
+++ b/src/registry/app-start.js
@@ -54,9 +54,7 @@ module.exports = function(repository, options, callback) {
             logger.log(colors.green('Component published.'));
           } else {
             logger.log(
-              colors.red(
-                format('Component not published: {0}', _.first(err).message)
-              )
+              colors.red(format('Component not published: {0}', err.message))
             );
           }
 

--- a/test/unit/registry-domain-s3.js
+++ b/test/unit/registry-domain-s3.js
@@ -88,6 +88,30 @@ describe('registry : domain : s3', () => {
     );
   };
 
+  const initialiseAndExecutePutDirWithError = callback => {
+    initialise();
+    const send = sinon.stub().yields({
+      code: 1234,
+      message: 'an error message',
+      retryable: true,
+      statusCode: 500,
+      time: new Date(),
+      hostname: 'hostname',
+      region: 'us-west2'
+    });
+
+    mockedS3Client.upload.returns({ send });
+    s3.putDir(
+      '/absolute-path-to-dir',
+      'components\\componentName\\1.0.0',
+      (err, res) => {
+        error = err;
+        response = res;
+        callback();
+      }
+    );
+  };
+
   describe('when bucket is empty', () => {
     describe("when trying to access a path that doesn't exist", () => {
       before(done => {
@@ -250,24 +274,32 @@ describe('registry : domain : s3', () => {
   });
 
   describe('when publishing directory', () => {
-    before(done => {
-      initialiseAndExecutePutDir(done);
+    describe('on success', () => {
+      before(done => initialiseAndExecutePutDir(done));
+
+      it('should save all the files', () => {
+        expect(mockedS3Client.upload.args.length).to.equal(3);
+      });
+
+      it('should save the files using unix-styled path for s3 output locations', () => {
+        expect(mockedS3Client.upload.args[0][0].Key).to.eql(
+          'components/componentName/1.0.0/package.json'
+        );
+        expect(mockedS3Client.upload.args[1][0].Key).to.eql(
+          'components/componentName/1.0.0/server.js'
+        );
+        expect(mockedS3Client.upload.args[2][0].Key).to.eql(
+          'components/componentName/1.0.0/template.js'
+        );
+      });
     });
 
-    it('should save all the files', () => {
-      expect(mockedS3Client.upload.args.length).to.equal(3);
-    });
+    describe('on failure', () => {
+      before(done => initialiseAndExecutePutDirWithError(done));
 
-    it('should save the files using unix-styled path for s3 output locations', () => {
-      expect(mockedS3Client.upload.args[0][0].Key).to.eql(
-        'components/componentName/1.0.0/package.json'
-      );
-      expect(mockedS3Client.upload.args[1][0].Key).to.eql(
-        'components/componentName/1.0.0/server.js'
-      );
-      expect(mockedS3Client.upload.args[2][0].Key).to.eql(
-        'components/componentName/1.0.0/template.js'
-      );
+      it('should get the error', () => {
+        expect(error.message).to.equal('an error message');
+      });
     });
   });
 


### PR DESCRIPTION
Fixes #696 

I double checked the s3 error API: http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Response.html#error-property and added a test to fix the issue.

When we were using `give-me` instead of `async` the error could be an array: https://github.com/opentable/oc/blob/43841cd446b01975bee204941ce66399cb5899ed/registry/domain/s3.js#L109 but the putDir method in s3 is now the result of an `async.each` which returns the first error that encounters.