### PR TITLE
Infinite npm i loop fix

### DIFF
--- a/src/utils/npm-utils.js
+++ b/src/utils/npm-utils.js
@@ -4,7 +4,7 @@ const path = require('path');
 const spawn = require('cross-spawn');
 
 const buildInstallCommand = options => {
-  const args = ['install'];
+  const args = ['install', '--prefix', options.installPath];
 
   if (options.save) {
     args.push('--save-exact');
@@ -39,8 +39,8 @@ module.exports = {
           ? null
           : {
             dest: dependencies.map(dependency =>
-                path.join(installPath, 'node_modules', moduleName(dependency))
-              )
+              path.join(installPath, 'node_modules', moduleName(dependency))
+            )
           }
       )
     );
@@ -57,10 +57,10 @@ module.exports = {
           ? null
           : {
             dest: path.join(
-                installPath,
-                'node_modules',
-                moduleName(dependency)
-              )
+              installPath,
+              'node_modules',
+              moduleName(dependency)
+            )
           }
       )
     );

--- a/test/unit/utils-npm-utils.js
+++ b/test/unit/utils-npm-utils.js
@@ -25,6 +25,8 @@ describe('utils : npm-utils', () => {
         },
         output: [
           'install',
+          '--prefix',
+          'path/to/component',
           '--save-exact',
           '--save-dev',
           'oc-template-jade-compiler'
@@ -37,7 +39,7 @@ describe('utils : npm-utils', () => {
           isDev: true,
           save: false
         },
-        output: ['install', 'lodash']
+        output: ['install', '--prefix', 'path/to/component', 'lodash']
       },
       {
         input: {
@@ -46,11 +48,18 @@ describe('utils : npm-utils', () => {
           isDev: false,
           save: true
         },
-        output: ['install', '--save-exact', '--save', 'underscore']
+        output: [
+          'install',
+          '--prefix',
+          'path/to/component',
+          '--save-exact',
+          '--save',
+          'underscore'
+        ]
       },
       {
         input: { dependency: 'oc-client@~1.2.3', installPath, save: false },
-        output: ['install', 'oc-client@~1.2.3']
+        output: ['install', '--prefix', 'path/to/component', 'oc-client@~1.2.3']
       }
     ];
 
@@ -104,6 +113,8 @@ describe('utils : npm-utils', () => {
         },
         output: [
           'install',
+          '--prefix',
+          'path/to/component',
           '--save-exact',
           '--save-dev',
           'oc-template-jade-compiler',
@@ -117,7 +128,7 @@ describe('utils : npm-utils', () => {
           isDev: true,
           save: false
         },
-        output: ['install', 'moment', 'lodash']
+        output: ['install', '--prefix', 'path/to/component', 'moment', 'lodash']
       },
       {
         input: {
@@ -126,7 +137,15 @@ describe('utils : npm-utils', () => {
           isDev: false,
           save: true
         },
-        output: ['install', '--save-exact', '--save', 'underscore', 'oc-client']
+        output: [
+          'install',
+          '--prefix',
+          'path/to/component',
+          '--save-exact',
+          '--save',
+          'underscore',
+          'oc-client'
+        ]
       },
       {
         input: {
@@ -134,7 +153,13 @@ describe('utils : npm-utils', () => {
           installPath,
           save: false
         },
-        output: ['install', 'oc-client@~1.2.3', 'oc-template-react-compiler']
+        output: [
+          'install',
+          '--prefix',
+          'path/to/component',
+          'oc-client@~1.2.3',
+          'oc-template-react-compiler'
+        ]
       }
     ];
 


### PR DESCRIPTION
Fixes a bug introduced on #686 

Specifically, when using npm as process (as opposite to programmatically as previously), running an npm i in a specific folder `doesn't` guarantee the module will be performed in the given folder.
In fact, if previous `node_modules` parents will be found, those will be picked instead. By using the `--prefix` param instead, that should be ok.

More info about how npm tries to guess the prefix if not specified explicitly: https://docs.npmjs.com/files/folders#more-information