### PR TITLE
passing prefix option to dev cmd

### DIFF
--- a/src/cli/commands.js
+++ b/src/cli/commands.js
@@ -37,6 +37,11 @@ module.exports = {
           boolean: true,
           description: 'Force packaging for production',
           default: false
+        },
+        prefix: {
+          boolean: false,
+          description: 'Url prefix for registry server',
+          default: ''
         }
       },
       usage: 'Usage: $0 dev <dirName> [port] [baseUrl] [options]'

--- a/src/cli/facade/dev.js
+++ b/src/cli/facade/dev.js
@@ -145,6 +145,7 @@ module.exports = function(dependencies) {
 
           const registry = new oc.Registry({
             baseUrl,
+            prefix: opts.prefix || '',
             dependencies: dependencies.modules,
             discovery: true,
             env: { name: 'local' },


### PR DESCRIPTION
The prefix option would be very useful to us while developing components and testing them locally in different contexts