### PR TITLE
[DX-296] Mocks can have the same signature as real plugins

### DIFF
--- a/src/cli/domain/get-mocked-plugins.js
+++ b/src/cli/domain/get-mocked-plugins.js
@@ -65,8 +65,8 @@ const findPath = function(pathToResolve, fileName) {
     if (pathToResolve === rootDir) {
       return undefined;
     } else {
-      const getParent = x =>
-        x
+      const getParent = pathToResolve =>
+        pathToResolve
           .split('/')
           .slice(0, -1)
           .join('/');

--- a/src/resources/index.js
+++ b/src/resources/index.js
@@ -1,6 +1,25 @@
 'use strict';
 const colors = require('colors/safe');
 
+const validFunctionMock = `// simplified mock signature
+module.exports = (a, b) => a+b;`;
+
+const validMockObject = `// standard plugin-like signature
+
+const dbClient = require('my-db-client');
+let cache;
+
+module.exports.register = (options, dependencies, next) => {
+  let client = dbClient(options);
+  client.init((err, response) => {
+    cache = response;
+    next(err);
+  });
+};
+
+module.exports.execute = key => cache[key];
+`;
+
 module.exports = {
   commands: {
     cli: {
@@ -91,7 +110,9 @@ module.exports = {
     },
     cli: {
       scaffoldError: (url, error) =>
-        `Scaffolding failed. Please open an issue on ${url} with the following information: ${error}`,
+        `Scaffolding failed. Please open an issue on ${
+          url
+        } with the following information: ${error}`,
       COMPONENT_HREF_NOT_FOUND:
         "The specified path is not a valid component's url",
       COMPONENTS_NOT_FOUND: 'no components found in specified path',
@@ -102,8 +123,13 @@ module.exports = {
       DEV_FAIL: 'An error happened when initialising the dev runner: {0}',
       INIT_FAIL: 'An error happened when initialising the component: {0}',
       INVALID_CREDENTIALS: 'Invalid credentials',
-      MOCK_PLUGIN_IS_NOT_A_FUNCTION:
-        'Looks like you are trying to register a dynamic mock plugin but the file you specified is not a function',
+      MOCK_PLUGIN_IS_NOT_VALID: `Looks like you are trying to register a dynamic mock plugin but the file you specified is not a valid mock.
+The entry point should be a synchronous function or an object containing an asynchronous register() function and a synchronous execute() function.
+Example:
+
+${colors.yellow(validFunctionMock)}
+
+${colors.yellow(validMockObject)}`,
       NAME_NOT_VALID:
         'the name is not valid. Allowed characters are alphanumeric, _, -',
       NODE_CLI_VERSION_NEEDS_UPGRADE:
@@ -164,7 +190,9 @@ Happy coding
       installCompilerSuccess: (template, compiler, version) =>
         `${colors.green('✔')} Installed ${compiler} [${template} v${version}]`,
       legacyTemplateDeprecationWarning: (legacyType, newType) =>
-        `Template-type "${legacyType}" has been deprecated and is now replaced by "${newType}"`,
+        `Template-type "${
+          legacyType
+        }" has been deprecated and is now replaced by "${newType}"`,
       CHANGES_DETECTED: 'Changes detected on file: {0}',
       CHECKING_DEPENDENCIES: 'Ensuring dependencies are loaded...',
       COMPONENT_INITED: 'Success! Created "{0}"',


### PR DESCRIPTION
This allows a plugin to have, apart from the simplified signature (exporting a synchronous execution function) a regular signature (similar to the real plugins) with an exported asynchronous register() function and a synchronous exported execute() function.

This is part of a bigger work to allow mocks to be more usable and possibly wrapping the whole real plugin - for better local DX and testing.

PS
In case of plugin initialisation error, I improved the error message providing some code snippets for modelling a mock with the correct signature:
<img width="799" alt="screen shot 2017-12-20 at 15 26 51" src="https://user-images.githubusercontent.com/1789893/34217118-6a37ad76-e5a2-11e7-8489-35519d008cee.png">
