### PR TITLE
[DX-366] Allow usage of protocol  in storage.options.path

### DIFF
--- a/src/registry/domain/options-sanitiser.js
+++ b/src/registry/domain/options-sanitiser.js
@@ -77,6 +77,13 @@ module.exports = function(input) {
     options.storage.options.verbosity = options.verbosity;
   }
 
+  if (options.storage && options.storage.path) {
+    options.storage.path =
+      options.storage.path.indexOf('http') === 0
+        ? options.storage.path
+        : `https:${options.storage.path}`;
+  }
+
   if (!options.env) {
     options.env = {};
   }

--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -19,6 +19,10 @@ const errorToString = require('../../utils/error-to-string');
 module.exports = function(conf) {
   const cdn = !conf.local && new conf.storage.adapter(conf.storage.options);
   const options = !conf.local && conf.storage.options;
+  const storagePath =
+    options && options.path.match(/^http/)
+      ? options.path
+      : `https:${options.path}`;
   const repositorySource = conf.local
     ? 'local repository'
     : cdn.adapterType + ' cdn';
@@ -204,7 +208,7 @@ module.exports = function(conf) {
     getComponentPath: (componentName, componentVersion) => {
       const prefix = conf.local
         ? conf.baseUrl
-        : `https:${options.path}${options.componentsDir}/`;
+        : `${storagePath}${options.componentsDir}/`;
       return `${prefix}${componentName}/${componentVersion}/`;
     },
     getComponents: callback => {
@@ -248,14 +252,14 @@ module.exports = function(conf) {
       );
     },
     getStaticClientPath: () =>
-      `https:${options.path}${getFilePath(
+      `${storagePath}${getFilePath(
         'oc-client',
         packageInfo.version,
         'src/oc-client.min.js'
       )}`,
 
     getStaticClientMapPath: () =>
-      `https:${options.path}${getFilePath(
+      `${storagePath}${getFilePath(
         'oc-client',
         packageInfo.version,
         'src/oc-client.min.map'

--- a/src/registry/domain/repository.js
+++ b/src/registry/domain/repository.js
@@ -19,10 +19,6 @@ const errorToString = require('../../utils/error-to-string');
 module.exports = function(conf) {
   const cdn = !conf.local && new conf.storage.adapter(conf.storage.options);
   const options = !conf.local && conf.storage.options;
-  const storagePath =
-    options && options.path.match(/^http/)
-      ? options.path
-      : `https:${options.path}`;
   const repositorySource = conf.local
     ? 'local repository'
     : cdn.adapterType + ' cdn';
@@ -208,7 +204,7 @@ module.exports = function(conf) {
     getComponentPath: (componentName, componentVersion) => {
       const prefix = conf.local
         ? conf.baseUrl
-        : `${storagePath}${options.componentsDir}/`;
+        : `${options.path}${options.componentsDir}/`;
       return `${prefix}${componentName}/${componentVersion}/`;
     },
     getComponents: callback => {
@@ -252,14 +248,14 @@ module.exports = function(conf) {
       );
     },
     getStaticClientPath: () =>
-      `${storagePath}${getFilePath(
+      `${options.path}${getFilePath(
         'oc-client',
         packageInfo.version,
         'src/oc-client.min.js'
       )}`,
 
     getStaticClientMapPath: () =>
-      `${storagePath}${getFilePath(
+      `${options.path}${getFilePath(
         'oc-client',
         packageInfo.version,
         'src/oc-client.min.map'

--- a/test/unit/registry-domain-options-sanitiser.js
+++ b/test/unit/registry-domain-options-sanitiser.js
@@ -136,4 +136,83 @@ describe('registry : domain : options-sanitiser', () => {
       });
     });
   });
+
+  describe('storage adapter configuration', () => {
+    describe('when legacy "s3" param', () => {
+      describe('is provided', () => {
+        const options = { s3: { some: 'data' }, baseUrl: 'dummy' };
+        it('should create a storage.adapter configuration accordingly', () => {
+          expect(sanitise(options).storage.options).to.deep.equal({
+            some: 'data'
+          });
+          expect(sanitise(options).storage.adapter).to.equal(
+            require('oc-s3-storage-adapter')
+          );
+        });
+      });
+    });
+    describe('when no storage adapter', () => {
+      describe('is provided', () => {
+        const options = { storage: {}, baseUrl: 'dummy' };
+        it('should default to the oc-s3-storage-adapter', () => {
+          expect(sanitise(options).storage.adapter).to.equal(
+            require('oc-s3-storage-adapter')
+          );
+        });
+      });
+    });
+
+    describe('when refreshInterval', () => {
+      describe('is provided', () => {
+        const options = {
+          refreshInterval: 666,
+          storage: { options: {} },
+          baseUrl: 'dummy'
+        };
+        it('should pass the refreshInterval to the storage options', () => {
+          expect(sanitise(options).storage.options.refreshInterval).to.equal(
+            666
+          );
+        });
+      });
+    });
+
+    describe('when verbosity', () => {
+      describe('is provided', () => {
+        const options = {
+          verbosity: true,
+          storage: { options: {} },
+          baseUrl: 'dummy'
+        };
+        it('should pass the verbosity to the storage options', () => {
+          expect(sanitise(options).storage.options.verbosity).to.equal(true);
+        });
+      });
+    });
+
+    describe('when storage.path', () => {
+      describe('does not include a protocol', () => {
+        const options = {
+          storage: { path: '//someprovider.com' },
+          baseUrl: 'dummy'
+        };
+        it('should sanitize the path to rely on the https protocol', () => {
+          expect(sanitise(options).storage.path).to.equal(
+            'https://someprovider.com'
+          );
+        });
+      });
+      describe('does include a prefix', () => {
+        const options = {
+          storage: { path: 'http://someprovider.com' },
+          baseUrl: 'dummy'
+        };
+        it('should not modify it', () => {
+          expect(sanitise(options).storage.path).to.equal(
+            'http://someprovider.com'
+          );
+        });
+      });
+    });
+  });
 });

--- a/test/unit/registry-domain-repository.js
+++ b/test/unit/registry-domain-repository.js
@@ -68,7 +68,7 @@ describe('registry : domain : repository', () => {
           bucket: 'walter-test',
           region: 'us-west-2',
           componentsDir: 'components',
-          path: '//s3.amazonaws.com/walter-test/'
+          path: 'https://s3.amazonaws.com/walter-test/'
         }
       }
     };


### PR DESCRIPTION
If no protocol is provided (current legacy usage) default to https.
cc @johnparn

related issue - https://github.com/opencomponents/storage-adapters/issues/34

📝  Update [documentation](https://github.com/opentable/oc/wiki/Registry#registry-configuration) once this get published